### PR TITLE
fix: Improve mod enabling logic during install

### DIFF
--- a/src/GIMI-ModManager.WinUI/ViewModels/ModInstallerVM.cs
+++ b/src/GIMI-ModManager.WinUI/ViewModels/ModInstallerVM.cs
@@ -228,15 +228,15 @@ public partial class ModInstallerVM : ObservableRecipient, INavigationAware, IDi
         {
             Task.Run(() =>
             {
-                if (_characterModList.Mods.Count >= 1)
-                {
-                    //false if all the mods are disabled or there are no mods other than the new one
-                    var anyEnabled = _characterModList.Mods.Where(entry => entry.Mod.Id != newMod.Id).Any(entry => entry.IsEnabled);
+                if (_characterModList.Mods.Count == 0) return;
 
-                    if (anyEnabled)
-                        DisableMod(newMod);
-                }
+                // False if all the mods are disabled or there are no mods other than the new one
+                var anyEnabled = _characterModList.Mods
+                    .Where(entry => entry.Mod.Id != newMod.Id)
+                    .Any(entry => entry.IsEnabled);
 
+                if (anyEnabled)
+                    DisableMod(newMod);
             });
         }
 

--- a/src/GIMI-ModManager.WinUI/ViewModels/ModInstallerVM.cs
+++ b/src/GIMI-ModManager.WinUI/ViewModels/ModInstallerVM.cs
@@ -224,6 +224,21 @@ public partial class ModInstallerVM : ObservableRecipient, INavigationAware, IDi
 
         if (EnableThisMod)
             Task.Run(() => EnableOnlyMod(newMod));
+        else
+        {
+            Task.Run(() =>
+            {
+                if (_characterModList.Mods.Count >= 1)
+                {
+                    //false if all the mods are disabled or there are no mods other than the new one
+                    var anyEnabled = _characterModList.Mods.Where(entry => entry.Mod.Id != newMod.Id).Any(entry => entry.IsEnabled);
+
+                    if (anyEnabled)
+                        DisableMod(newMod);
+                }
+
+            });
+        }
 
         _dispatcherQueue?.TryEnqueue(() => { _windowManagerService.GetWindow(_characterModList)?.Close(); });
 


### PR DESCRIPTION
**Previous behaviour**: if the checkbox "Enable this mod and disable others?" was `unchecked` the newly installed mod would be left enabled.
**Problem**: if there are other mods already installed to a certain CharEntry the newly installed mod is left enabled and needs to be disabled manually to avoid mod conflict.
**Solution**: Added piece of logic that checks if there are other enabled mods on the same CharEntry and, in case there are, disables the newly installed mod automatically.

No logic changes in case the checkbox mentioned above is checked.

PS: feel free to tell me if there are better ways to do something in code, the codebase seems is quite big and i still haven't even scratched the surface in exploring it, and i also don't have much experience with WinUI 3.