### PR TITLE
Limited the number of active tasks queued at the same time in ModUpdateAvailableChecker

### DIFF
--- a/src/GIMI-ModManager.WinUI/App.xaml.cs
+++ b/src/GIMI-ModManager.WinUI/App.xaml.cs
@@ -166,8 +166,8 @@ public partial class App : Application
                 {
                     var limiter = new TokenBucketRateLimiter(new TokenBucketRateLimiterOptions()
                     {
-                        QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
-                        QueueLimit = 0,
+                        QueueProcessingOrder = QueueProcessingOrder.NewestFirst,
+                        QueueLimit = 20,
                         TokenLimit = 5,
                         AutoReplenishment = true,
 #if DEBUG


### PR DESCRIPTION
Before this change, the ModUpdateAvailableChecker would queue a new task for each mod that needed to be checked for updates.
With a lot of mods, a large number of tasks would be queued at the same time, because of the rate limiter they would all be rejected, and the tasks would be requeued again. With many mods the UI would become laggy.
This change limits the number of active tasks that can be queued at the same time to 20, this should improve app responsiveness during a mod update check, especially with a large number of mods.