### PR TITLE
Many smaller features and changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-﻿# JASM - Just Another Skin Manager
+# JASM - Just Another Skin Manager
 
 JASM is a skin manager for a certain game. Made using WinUI 3 with WinAppSDK. 
 I made this for fun, for myself and to learn WinUI, but it kinda took off over time.
@@ -94,6 +94,27 @@ The code has progressively gotten more spaghettified over time ;_;
 I believe this is due to some oddity with WinAppSdk not installing correctly. I do not know what causes this. A temporary (permanent?) solution is to use the self contained version of JASM that does not require WinAppSdk or .NET. See the releases page [SelfContainted_JASM_vx.x.x.7z](https://github.com/Jorixon/JASM/releases). Ref [#72](https://github.com/Jorixon/JASM/issues/72) and [#171](https://github.com/Jorixon/JASM/issues/171)
 
 Another potential fix if JASM used to work, is to delete the JASM user settings folder. This will wipe your settings i.e. presets, folder paths etc. However, your mods will be untouched as well as the mod settings like custom display name and images. JASM settings are stored here: `%localappdata%\JASM` / `C:\Users\<username>\AppData\Local\JASM`. You can start by deleting each game settings folder to see if it helps, alternativly just delete the entire folder. Presets are stored inside the preset folder. Might be a good idea make a backup first.
+
+
+### Command line support
+
+JASM has basic command line support. As of now the only supported functionality is to start directly into a selected game. If you would like to see more command line options, feel free to open an issue with your suggested use case.
+
+See --help for more information.
+
+Powershell:
+```powershell
+.\'JASM - Just Another Skin Manager.exe' --help
+# Example: Close the current instance if it is running and start JASM with the selected game
+.\'JASM - Just Another Skin Manager.exe' --switch --game genshin
+```
+
+### Memory usage is high
+
+For each page navigated a lot of memory is allocated and not released. This causes the app to quickly use more than 1GB of memory by quickly navigating between pages. This isn't a quick fix. I suggest restarting the app if you notice it getting slow.
+
+From my research WinUI seems to maybe have a memory leak when navigating pages. I am not sure if this is the case or if I am doing something wrong. Most of the memory is unmanaged memory which means a memory profiler won't help much. 
+
 
 ### Elevator download link
 

--- a/src/GIMI-ModManager.Core/Services/GameBanana/ApiGameBananaCache.cs
+++ b/src/GIMI-ModManager.Core/Services/GameBanana/ApiGameBananaCache.cs
@@ -36,6 +36,16 @@ internal sealed class ApiGameBananaCache
         return null;
     }
 
+    public T[] GetAll<T>() where T : class
+    {
+        ClearExpiredEntries();
+
+        return _cache
+            .Where(x => x.Key.StartsWith($"{typeof(T).Name}_"))
+            .Select(x => (T)x.Value.Value)
+            .ToArray();
+    }
+
 
     public void Set<T>(string key, T value, TimeSpan? cacheDuration = null) where T : class
     {

--- a/src/GIMI-ModManager.Core/Services/GameBanana/GameBannaUrlHelper.cs
+++ b/src/GIMI-ModManager.Core/Services/GameBanana/GameBannaUrlHelper.cs
@@ -1,0 +1,29 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using GIMI_ModManager.Core.Services.GameBanana.Models;
+
+namespace GIMI_ModManager.Core.Services.GameBanana;
+
+public static class GameBananaUrlHelper
+{
+    public static bool TryGetModIdFromUrl(Uri url, [NotNullWhen(true)] out GbModId? modId)
+    {
+        modId = null;
+
+        if (url.Host != "gamebanana.com" || url.Scheme != Uri.UriSchemeHttps)
+            return false;
+
+
+        var segments = url.Segments;
+
+        if (segments.Length < 2)
+            return false;
+
+        modId = new GbModId(segments.Last());
+
+        if (modId.ModId.Contains('/'))
+            return false;
+
+        return true;
+    }
+
+}

--- a/src/GIMI-ModManager.Core/Services/GameBanana/ModArchiveRepository.cs
+++ b/src/GIMI-ModManager.Core/Services/GameBanana/ModArchiveRepository.cs
@@ -226,11 +226,12 @@ public sealed class ModArchiveRepository
         return archiveFile;
     }
 
+    public double GetTotalCacheSizeInGB() => _modArchives.Sum(x => x.Value.SizeInGb);
 
     private void RemoveUntilUnderMaxSize()
     {
         // Remove archives until the directory is under the max size
-        var currentSize = _modArchives.Sum(x => x.Value.SizeInGb);
+        var currentSize = GetTotalCacheSizeInGB();
 
         if (currentSize > _maxDirectorySizeGb)
         {

--- a/src/GIMI-ModManager.Core/Services/ModPresetService/Models/ModPresetEntry.cs
+++ b/src/GIMI-ModManager.Core/Services/ModPresetService/Models/ModPresetEntry.cs
@@ -24,7 +24,7 @@ public class ModPresetEntry
     public string Name => ModFolderHelpers.GetFolderNameWithoutDisabledPrefix(new DirectoryInfo(FullPath).Name);
 
 
-    public IReadOnlyDictionary<string, string>? Preferences { get; init; }
+    public IReadOnlyDictionary<string, string>? Preferences { get; private set; }
 
     public DateTime? AddedAt { get; internal set; }
 
@@ -58,6 +58,11 @@ public class ModPresetEntry
             SourceUrl = settings.ModUrl,
             AddedAt = DateTime.Now
         };
+    }
+
+    internal void UpdatePreferences(IEnumerable<KeyValuePair<string, string>>? preferences)
+    {
+        Preferences = preferences?.ToDictionary();
     }
 
     internal static ModPresetEntry FromJson(JsonModPresetEntry json)

--- a/src/GIMI-ModManager.WinUI/GIMI-ModManager.WinUI.csproj
+++ b/src/GIMI-ModManager.WinUI/GIMI-ModManager.WinUI.csproj
@@ -622,6 +622,7 @@
 		<None Remove="Views\DebugPage.xaml" />
 		<None Remove="Views\EasterEggPage.xaml" />
 		<None Remove="Views\ErrorWindow.xaml" />
+		<None Remove="Views\GbModPageWindow.xaml" />
 		<None Remove="Views\ModInstallerPage.xaml" />
 		<None Remove="Views\ModSelector.xaml" />
 		<None Remove="Views\ModsOverviewPage.xaml" />
@@ -702,6 +703,12 @@
 			<Generator>MSBuild:Compile</Generator>
 		</Page>
 		<Page Update="Views\Controls\BoolBorder.xaml">
+			<Generator>MSBuild:Compile</Generator>
+		</Page>
+		<Page Update="Views\GbModPageWindow.xaml">
+			<Generator>MSBuild:Compile</Generator>
+		</Page>
+		<Page Update="Views\GbModPageWindow.xaml">
 			<Generator>MSBuild:Compile</Generator>
 		</Page>
 		<Page Update="Views\ModUpdateAvailableWindow.xaml">

--- a/src/GIMI-ModManager.WinUI/Models/Settings/CharacterOverviewSettings.cs
+++ b/src/GIMI-ModManager.WinUI/Models/Settings/CharacterOverviewSettings.cs
@@ -10,4 +10,5 @@ public class CharacterOverviewSettings
     public bool ShowOnlyCharactersWithMods { get; set; } = false;
     public bool SortByDescending { get; set; } = false;
     public string? SortingMethod { get; set; }
+    public bool ShowOnlyModsWithNotifications { get; set; }
 }

--- a/src/GIMI-ModManager.WinUI/NativeMethods.txt
+++ b/src/GIMI-ModManager.WinUI/NativeMethods.txt
@@ -3,3 +3,5 @@ SetWindowPos
 SetForegroundWindow
 PlaySound
 PathFindOnPath
+AttachConsole
+GetWindowThreadProcessId

--- a/src/GIMI-ModManager.WinUI/Properties/launchsettings.json
+++ b/src/GIMI-ModManager.WinUI/Properties/launchsettings.json
@@ -1,10 +1,11 @@
-﻿{
-    "profiles": {
-      "GIMI-ModManager.WinUI (Unpackaged)": {
-        "commandName": "Project"
-      }
-      //"GIMI-ModManager.WinUI (Package)": {
-      //  "commandName": "MsixPackage"
-      //}
+{
+  "profiles": {
+    "GIMI-ModManager.WinUI (Unpackaged)": {
+      "commandName": "Project"
+    },
+    "JASM Start ZZZ": {
+      "commandName": "Project",
+      "commandLineArgs": "--game zzz --switch"
     }
+  }
 }

--- a/src/GIMI-ModManager.WinUI/Services/ImageHandlerService.cs
+++ b/src/GIMI-ModManager.WinUI/Services/ImageHandlerService.cs
@@ -205,4 +205,23 @@ public class ImageHandlerService
 
         return tmpImage;
     }
+
+    public async Task<StorageFile?> CopyImageToTmpFolder(Uri? uri)
+    {
+        if (uri is null)
+            return null;
+
+        if (uri.Scheme == Uri.UriSchemeHttps && uri.IsAbsoluteUri)
+        {
+            return await DownloadImageAsync(uri).ConfigureAwait(false);
+        }
+
+        if (uri.Scheme == Uri.UriSchemeFile)
+        {
+            var file = await StorageFile.GetFileFromPathAsync(uri.LocalPath);
+            return await CopyImageToTmpFolder(file).ConfigureAwait(false);
+        }
+
+        return null;
+    }
 }

--- a/src/GIMI-ModManager.WinUI/Services/ModHandling/ModDragAndDropService.cs
+++ b/src/GIMI-ModManager.WinUI/Services/ModHandling/ModDragAndDropService.cs
@@ -6,6 +6,7 @@ using GIMI_ModManager.Core.Services;
 using GIMI_ModManager.WinUI.Services.AppManagement;
 using Serilog;
 using static GIMI_ModManager.WinUI.Services.ModHandling.ModDragAndDropService.DragAndDropFinishedArgs;
+using GIMI_ModManager.WinUI.Views;
 
 namespace GIMI_ModManager.WinUI.Services.ModHandling;
 
@@ -195,6 +196,27 @@ public class ModDragAndDropService
         }
     }
 
+
+    public async Task AddModFromUrlAsync(ICharacterModList modList, Uri uri)
+    {
+        var windowKey = $"ModPage_{modList.Character.InternalName}";
+        if (_windowManagerService.GetWindow(windowKey) is { } window)
+        {
+            PInvoke.PlaySound("SystemAsterisk", null,
+                SND_FLAGS.SND_ASYNC | SND_FLAGS.SND_ALIAS | SND_FLAGS.SND_NODEFAULT);
+
+            App.MainWindow.DispatcherQueue.TryEnqueue(() => window.Activate());
+            return;
+        }
+
+
+        var modWindow = new GbModPageWindow(uri, modList.Character);
+        _windowManagerService.CreateWindow(modWindow, identifier: windowKey);
+        await Task.Delay(100);
+        modWindow.BringToFront();
+
+        DragAndDropFinished?.Invoke(this, new DragAndDropFinishedArgs(new List<ExtractPaths>()));
+    }
 
     public class DragAndDropFinishedArgs : EventArgs
     {

--- a/src/GIMI-ModManager.WinUI/Services/ModHandling/ModInstallerService.cs
+++ b/src/GIMI-ModManager.WinUI/Services/ModHandling/ModInstallerService.cs
@@ -80,6 +80,7 @@ public class ModInstallerService(
 public class InstallOptions
 {
     public Uri? ModUrl { get; set; }
+    public Guid? ExistingModIdToUpdate { get; set; }
 }
 
 public sealed class InstallMonitor : IDisposable

--- a/src/GIMI-ModManager.WinUI/Services/Notifications/ModNotificationManager.cs
+++ b/src/GIMI-ModManager.WinUI/Services/Notifications/ModNotificationManager.cs
@@ -57,7 +57,7 @@ public class ModNotificationManager(
         if (modNotificationRoot is null)
         {
             logger.Warning("Mod notifications file is in an invalid format. Creating a new one");
-            _modNotificationsFile.Delete();
+            _modNotificationsFile.CopyTo(_modNotificationsFile.FullName + ".invalid", true);
             modNotificationRoot = new ModNotificationsRoot("1.0");
             var fileStream = _modNotificationsFile.Create();
             await JsonSerializer.SerializeAsync(fileStream, modNotificationRoot, _jsonSerializerOptions)

--- a/src/GIMI-ModManager.WinUI/ViewModels/CharacterDetailsViewModel.cs
+++ b/src/GIMI-ModManager.WinUI/ViewModels/CharacterDetailsViewModel.cs
@@ -71,11 +71,6 @@ public partial class CharacterDetailsViewModel : ObservableRecipient, INavigatio
 
     [ObservableProperty] private bool _isICharacter = false;
 
-    [ObservableProperty] [NotifyPropertyChangedFor(nameof(IsFullPagerLoaderHidden))]
-    private bool _isFullPageLoaderVisible = true;
-
-    public bool IsFullPagerLoaderHidden => !IsFullPageLoaderVisible;
-
 
     public CharacterDetailsViewModel(IGameService gameService, ILogger logger,
         INavigationService navigationService, ISkinManagerService skinManagerService,

--- a/src/GIMI-ModManager.WinUI/ViewModels/CharacterDetailsViewModel.cs
+++ b/src/GIMI-ModManager.WinUI/ViewModels/CharacterDetailsViewModel.cs
@@ -71,6 +71,11 @@ public partial class CharacterDetailsViewModel : ObservableRecipient, INavigatio
 
     [ObservableProperty] private bool _isICharacter = false;
 
+    [ObservableProperty] [NotifyPropertyChangedFor(nameof(IsFullPagerLoaderHidden))]
+    private bool _isFullPageLoaderVisible = true;
+
+    public bool IsFullPagerLoaderHidden => !IsFullPageLoaderVisible;
+
 
     public CharacterDetailsViewModel(IGameService gameService, ILogger logger,
         INavigationService navigationService, ISkinManagerService skinManagerService,

--- a/src/GIMI-ModManager.WinUI/ViewModels/ModInstallerVM.cs
+++ b/src/GIMI-ModManager.WinUI/ViewModels/ModInstallerVM.cs
@@ -110,6 +110,7 @@ public partial class ModInstallerVM : ObservableRecipient, INavigationAware, IDi
     [ObservableProperty] private bool _replaceDuplicateModInPreset;
 
     public bool IsUpdatingMod => _installOptions?.ExistingModIdToUpdate is not null;
+    private ISkinMod? _existingModToUpdate;
 
     public readonly string RootFolderIcon = "\uF89A";
     public readonly string ShaderFixesFolderIcon = "\uE710";
@@ -165,6 +166,10 @@ public partial class ModInstallerVM : ObservableRecipient, INavigationAware, IDi
 
         await Task.Run(async () =>
         {
+            _existingModToUpdate = _installOptions?.ExistingModIdToUpdate is not null
+                ? _skinManagerService.GetModById(_installOptions.ExistingModIdToUpdate.Value)
+                : null;
+
             var modDir = _modInstallation.AutoSetModRootFolder();
             if (modDir is not null)
             {
@@ -637,9 +642,9 @@ public partial class ModInstallerVM : ObservableRecipient, INavigationAware, IDi
         {
             oldMod = _duplicateMod;
         }
-        else if (ReplaceModToUpdateInPreset && _installOptions?.ExistingModIdToUpdate != null)
+        else if (ReplaceModToUpdateInPreset && _installOptions?.ExistingModIdToUpdate != null && _existingModToUpdate?.Id == _installOptions.ExistingModIdToUpdate.Value)
         {
-            oldMod = _skinManagerService.GetModById(_installOptions.ExistingModIdToUpdate.Value);
+            oldMod = _existingModToUpdate;
         }
 
         try

--- a/src/GIMI-ModManager.WinUI/ViewModels/ModInstallerVM.cs
+++ b/src/GIMI-ModManager.WinUI/ViewModels/ModInstallerVM.cs
@@ -65,7 +65,8 @@ public partial class ModInstallerVM : ObservableRecipient, INavigationAware, IDi
 
     [ObservableProperty] private string _modCharacterName = string.Empty;
 
-    [ObservableProperty] [NotifyCanExecuteChangedFor(nameof(ReRetrieveModInfoCommand))]
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(ReRetrieveModInfoCommand))]
     private bool _isRetrievingModInfo;
 
     [ObservableProperty] private FileSystemItem? _lastSelectedShaderFixesFolder;
@@ -85,7 +86,8 @@ public partial class ModInstallerVM : ObservableRecipient, INavigationAware, IDi
     [ObservableProperty] private Uri _modPreviewImagePath = App.GetService<ImageHandlerService>().PlaceholderImageUri;
     [ObservableProperty] private string _customName = string.Empty;
 
-    [ObservableProperty] [NotifyCanExecuteChangedFor(nameof(ReRetrieveModInfoCommand))]
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(ReRetrieveModInfoCommand))]
     private string _modUrl = string.Empty;
 
     [ObservableProperty] private string _author = string.Empty;

--- a/src/GIMI-ModManager.WinUI/ViewModels/ModPageViewModels/ModFileInfoVm.cs
+++ b/src/GIMI-ModManager.WinUI/ViewModels/ModPageViewModels/ModFileInfoVm.cs
@@ -1,0 +1,76 @@
+﻿using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using GIMI_ModManager.Core.Services.GameBanana.Models;
+using GIMI_ModManager.WinUI.Helpers;
+
+namespace GIMI_ModManager.WinUI.ViewModels.ModPageViewModels;
+
+public partial class ModFileInfoVm : ObservableObject
+{
+    private readonly ModFileInfo _modFileInfo;
+
+    public string ModId => _modFileInfo.ModId;
+    public string FileId => _modFileInfo.FileId;
+    public string FileName => _modFileInfo.FileName;
+
+    public DateTime DateAdded => _modFileInfo.DateAdded;
+
+    public string DateAddedTooltipFormat => $"Submitted: {DateAdded}";
+
+    public TimeSpan Age => DateTime.Now - DateAdded;
+
+    public string AgeFormated => FormaterHelpers.FormatTimeSinceAdded(Age);
+
+    public string Description => _modFileInfo.Description;
+
+    public string Md5Hash => _modFileInfo.Md5Checksum;
+    [ObservableProperty] private bool _isNew;
+
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(DownloadCommand), nameof(InstallCommand))]
+    [NotifyPropertyChangedFor(nameof(IsNotBusy))]
+    private bool _isBusy;
+
+    public bool IsNotBusy => !IsBusy;
+
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(DownloadCommand), nameof(InstallCommand))]
+    [NotifyPropertyChangedFor(nameof(ShowDownloadButton), nameof(ShowInstallButton))]
+    private InstallStatus _status = InstallStatus.NotStarted;
+
+    [ObservableProperty] private int _downloadProgress;
+
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(InstallCommand), nameof(DownloadCommand))]
+    private FileInfo? _archiveFile;
+
+    public IProgress<int> Progress { get; }
+
+
+    public bool ShowDownloadButton => Status is InstallStatus.NotStarted or InstallStatus.Downloading;
+
+    public bool ShowInstallButton =>
+        Status is InstallStatus.Downloaded or InstallStatus.Installing or InstallStatus.Installed;
+
+    public ModFileInfoVm(ModFileInfo modFileInfo,
+        IAsyncRelayCommand downloadCommand, IAsyncRelayCommand installCommand)
+    {
+        _modFileInfo = modFileInfo;
+        DownloadCommand = downloadCommand;
+        InstallCommand = installCommand;
+        Progress = new Progress<int>(i => DownloadProgress = i);
+    }
+
+    public IAsyncRelayCommand DownloadCommand { get; }
+    public IAsyncRelayCommand InstallCommand { get; }
+
+
+    public enum InstallStatus
+    {
+        NotStarted,
+        Downloading, // Downloading from GameBanana
+        Downloaded, // Downloaded from GameBanana
+        Installing, // Installing to the game, mod installation window open
+        Installed // Installed to the game
+    }
+}

--- a/src/GIMI-ModManager.WinUI/ViewModels/ModUpdateVM.cs
+++ b/src/GIMI-ModManager.WinUI/ViewModels/ModUpdateVM.cs
@@ -315,7 +315,11 @@ public partial class ModUpdateVM : ObservableRecipient
                 var modUrl = _modPageInfo?.ModPageUrl;
 
                 using var task = await _modInstallerService.StartModInstallationAsync(zipRoot, _characterModList,
-                    setup: options => options.ModUrl = modUrl).ConfigureAwait(false);
+                    setup: options =>
+                    {
+                        options.ModUrl = modUrl;
+                        options.ExistingModIdToUpdate = _notification?.ModId;
+                    }).ConfigureAwait(false);
 
                 return await task.WaitForCloseAsync(_ct).ConfigureAwait(false);
             }, _ct);

--- a/src/GIMI-ModManager.WinUI/ViewModels/SettingsViewModel.cs
+++ b/src/GIMI-ModManager.WinUI/ViewModels/SettingsViewModel.cs
@@ -13,6 +13,7 @@ using GIMI_ModManager.Core.GamesService;
 using GIMI_ModManager.Core.GamesService.Interfaces;
 using GIMI_ModManager.Core.Helpers;
 using GIMI_ModManager.Core.Services;
+using GIMI_ModManager.Core.Services.GameBanana;
 using GIMI_ModManager.WinUI.Contracts.Services;
 using GIMI_ModManager.WinUI.Contracts.ViewModels;
 using GIMI_ModManager.WinUI.Helpers;
@@ -48,6 +49,7 @@ public partial class SettingsViewModel : ObservableRecipient, INavigationAware
     private readonly ModUpdateAvailableChecker _modUpdateAvailableChecker;
     private readonly LifeCycleService _lifeCycleService;
     private readonly INavigationService _navigationService;
+    private readonly ModArchiveRepository _modArchiveRepository;
 
 
     private readonly NotificationManager _notificationManager;
@@ -112,6 +114,8 @@ public partial class SettingsViewModel : ObservableRecipient, INavigationAware
 
     private ModManagerOptions? _modManagerOptions = null!;
 
+    [ObservableProperty] private string _modCacheSizeGB = string.Empty;
+
     public SettingsViewModel(
         IThemeSelectorService themeSelectorService, ILocalSettingsService localSettingsService,
         ElevatorService elevatorService, ILogger logger, NotificationManager notificationManager,
@@ -120,7 +124,8 @@ public partial class SettingsViewModel : ObservableRecipient, INavigationAware
         GenshinProcessManager genshinProcessManager, ThreeDMigtoProcessManager threeDMigtoProcessManager,
         IGameService gameService, AutoUpdaterService autoUpdaterService, ILanguageLocalizer localizer,
         SelectedGameService selectedGameService, ModUpdateAvailableChecker modUpdateAvailableChecker,
-        LifeCycleService lifeCycleService, INavigationService navigationService)
+        LifeCycleService lifeCycleService, INavigationService navigationService,
+        ModArchiveRepository modArchiveRepository)
     {
         _themeSelectorService = themeSelectorService;
         _localSettingsService = localSettingsService;
@@ -137,6 +142,7 @@ public partial class SettingsViewModel : ObservableRecipient, INavigationAware
         _modUpdateAvailableChecker = modUpdateAvailableChecker;
         _lifeCycleService = lifeCycleService;
         _navigationService = navigationService;
+        _modArchiveRepository = modArchiveRepository;
         GenshinProcessManager = genshinProcessManager;
         ThreeDMigtoProcessManager = threeDMigtoProcessManager;
         _logger = logger.ForContext<SettingsViewModel>();
@@ -804,6 +810,7 @@ public partial class SettingsViewModel : ObservableRecipient, INavigationAware
         PersistWindowPosition = windowSettings.PersistWindowPosition;
         await GenshinProcessManager.TryInitialize();
         await ThreeDMigtoProcessManager.TryInitialize();
+        ModCacheSizeGB = _modArchiveRepository.GetTotalCacheSizeInGB().ToString("F");
     }
 
     [ObservableProperty] private string _maxCacheSizeString = string.Empty;

--- a/src/GIMI-ModManager.WinUI/Views/CharacterDetailsPage.xaml
+++ b/src/GIMI-ModManager.WinUI/Views/CharacterDetailsPage.xaml
@@ -307,500 +307,486 @@
                     Content="Disable All Mods" />
             </Grid>
 
-            <Grid Grid.Column="1" Visibility="{x:Bind ViewModel.IsFullPageLoaderVisible, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}">
-                <StackPanel
-                    HorizontalAlignment="Center"
-                    VerticalAlignment="Center"
-                    Spacing="16">
-                    <ProgressRing
-                        Width="50"
-                        Height="50"
-                        IsActive="True"
-                        IsIndeterminate="True" />
-                    <TextBlock Text="Loading..." />
-                </StackPanel>
-            </Grid>
 
-            <Grid Grid.Column="1" Visibility="{x:Bind ViewModel.IsFullPagerLoaderHidden, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}">
-                <Grid Margin="4,0,4,0">
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="Auto" />
-                        <RowDefinition />
-                    </Grid.RowDefinitions>
+            <Grid Grid.Column="1" Margin="4,0,4,0">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition />
+                </Grid.RowDefinitions>
 
-                    <Grid Margin="0,0,0,8">
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition />
-                            <ColumnDefinition />
-                        </Grid.ColumnDefinitions>
+                <Grid Margin="0,0,0,8">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition />
+                        <ColumnDefinition />
+                    </Grid.ColumnDefinitions>
 
-                        <StackPanel Orientation="Horizontal">
-                            <MenuBar>
-                                <MenuBarItem Title="Mods">
-                                    <MenuBarItem.Items>
-                                        <MenuFlyoutItem
-                                            Command="{x:Bind ViewModel.AddModFolderCommand}"
-                                            ToolTipService.ToolTip="Add a mod folder"
-                                            Text="Add Mod..." />
+                    <StackPanel Orientation="Horizontal">
+                        <MenuBar>
+                            <MenuBarItem Title="Mods">
+                                <MenuBarItem.Items>
+                                    <MenuFlyoutItem
+                                        Command="{x:Bind ViewModel.AddModFolderCommand}"
+                                        ToolTipService.ToolTip="Add a mod folder"
+                                        Text="Add Mod..." />
 
-                                        <MenuFlyoutItem
-                                            Command="{x:Bind ViewModel.AddModArchiveCommand}"
-                                            ToolTipService.ToolTip="Add a mod inside a compressed archive"
-                                            Text="Add Archive...">
-                                            <MenuFlyoutItem.KeyboardAccelerators>
-                                                <KeyboardAccelerator Key="O" Modifiers="Control" />
-                                            </MenuFlyoutItem.KeyboardAccelerators>
-                                        </MenuFlyoutItem>
+                                    <MenuFlyoutItem
+                                        Command="{x:Bind ViewModel.AddModArchiveCommand}"
+                                        ToolTipService.ToolTip="Add a mod inside a compressed archive"
+                                        Text="Add Archive...">
+                                        <MenuFlyoutItem.KeyboardAccelerators>
+                                            <KeyboardAccelerator Key="O" Modifiers="Control" />
+                                        </MenuFlyoutItem.KeyboardAccelerators>
+                                    </MenuFlyoutItem>
 
-                                        <MenuFlyoutSeparator />
-                                        <MenuFlyoutItem Command="{x:Bind ViewModel.RefreshModsCommand}" Text="Refresh Mods">
-                                            <MenuFlyoutItem.KeyboardAccelerators>
-                                                <KeyboardAccelerator Key="F5" />
-                                            </MenuFlyoutItem.KeyboardAccelerators>
-                                        </MenuFlyoutItem>
-                                    </MenuBarItem.Items>
-                                </MenuBarItem>
-
-                                <MenuBarItem Title="Folders">
-                                    <MenuFlyoutItem Command="{x:Bind ViewModel.OpenModsFolderCommand}" Text="Open Character's Mod folder..." />
                                     <MenuFlyoutSeparator />
-                                    <MenuFlyoutItem Command="{x:Bind ViewModel.OpenGIMIRootFolderCommand}" Text="Open 3Dmigoto Root folder..." />
-                                </MenuBarItem>
-                            </MenuBar>
+                                    <MenuFlyoutItem Command="{x:Bind ViewModel.RefreshModsCommand}" Text="Refresh Mods">
+                                        <MenuFlyoutItem.KeyboardAccelerators>
+                                            <KeyboardAccelerator Key="F5" />
+                                        </MenuFlyoutItem.KeyboardAccelerators>
+                                    </MenuFlyoutItem>
+                                </MenuBarItem.Items>
+                            </MenuBarItem>
 
-                        </StackPanel>
+                            <MenuBarItem Title="Folders">
+                                <MenuFlyoutItem Command="{x:Bind ViewModel.OpenModsFolderCommand}" Text="Open Character's Mod folder..." />
+                                <MenuFlyoutSeparator />
+                                <MenuFlyoutItem Command="{x:Bind ViewModel.OpenGIMIRootFolderCommand}" Text="Open 3Dmigoto Root folder..." />
+                            </MenuBarItem>
+                        </MenuBar>
 
-                        <StackPanel
-                            Grid.Column="1"
-                            HorizontalAlignment="Right"
+                    </StackPanel>
+
+                    <StackPanel
+                        Grid.Column="1"
+                        HorizontalAlignment="Right"
+                        VerticalAlignment="Center"
+                        Orientation="Horizontal"
+                        Spacing="16">
+
+                        <InfoBar
+                            Height="50"
                             VerticalAlignment="Center"
-                            Orientation="Horizontal"
-                            Spacing="16">
+                            IsClosable="False"
+                            IsOpen="{x:Bind ViewModel.ModListVM.IsInfoBarOpen, Mode=OneWay}"
+                            Message="{x:Bind ViewModel.ModListVM.InfoBarMessage, Mode=OneWay}"
+                            Severity="{x:Bind ViewModel.ModListVM.Severity, Mode=OneWay}"
+                            Visibility="Visible" />
 
-                            <InfoBar
-                                Height="50"
-                                VerticalAlignment="Center"
-                                IsClosable="False"
-                                IsOpen="{x:Bind ViewModel.ModListVM.IsInfoBarOpen, Mode=OneWay}"
-                                Message="{x:Bind ViewModel.ModListVM.InfoBarMessage, Mode=OneWay}"
-                                Severity="{x:Bind ViewModel.ModListVM.Severity, Mode=OneWay}"
-                                Visibility="Visible" />
+                        <ToggleSwitch
+                            x:Name="ViewToggleSwitch"
+                            IsOn="False"
+                            OffContent="Detailed View"
+                            OnContent="Gallery View"
+                            Toggled="ViewToggleSwitch_OnToggled" />
 
-                            <ToggleSwitch
-                                x:Name="ViewToggleSwitch"
-                                IsOn="False"
-                                OffContent="Detailed View"
-                                OnContent="Gallery View"
-                                Toggled="ViewToggleSwitch_OnToggled" />
-
-                            <Grid MinWidth="32">
-                                <ProgressRing IsActive="{x:Bind ViewModel.IsAddingModFolder, Mode=OneWay}" />
-                            </Grid>
-
-                        </StackPanel>
-
-                    </Grid>
-                    <Grid
-                        x:Name="MainContentArea"
-                        Grid.Row="1"
-                        AllowDrop="False"
-                        Background="Transparent"
-                        DragOver="ModListArea_OnDragOver"
-                        Drop="ModListArea_OnDrop">
-                        <Grid>
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="7*" />
-                                <ColumnDefinition Width="3*" />
-                            </Grid.ColumnDefinitions>
-                            <Grid
-                                x:Name="ModListArea"
-                                AllowDrop="True"
-                                Background="Transparent"
-                                CornerRadius="10"
-                                DragOver="ModListArea_OnDragOver"
-                                Drop="ModListArea_OnDrop">
-                                <controls:DataGrid
-                                    x:Name="ModListGrid"
-                                    AllowDrop="False"
-                                    AutoGenerateColumns="False"
-                                    CanUserReorderColumns="False"
-                                    CanUserResizeColumns="True"
-                                    CellEditEnded="ModListGrid_OnCellEditEnded"
-                                    ContextFlyout="{Binding ElementName=ModRowFlyout}"
-                                    FrozenColumnCount="3"
-                                    GridLinesVisibility="All"
-                                    ItemsSource="{x:Bind ViewModel.ModListVM.Mods, Mode=OneWay}"
-                                    KeyDown="ModListGrid_OnKeyDown"
-                                    SelectionChanged="ModListGrid_OnSelectionChanged"
-                                    SelectionMode="Extended"
-                                    Sorting="ModListGrid_OnSorting">
-                                    <controls:DataGrid.Columns>
-                                        <controls:DataGridTemplateColumn
-                                            Width="SizeToHeader"
-                                            CanUserResize="False"
-                                            CanUserSort="True"
-                                            Header="Enabled"
-                                            Tag="IsEnabled">
-
-                                            <controls:DataGridTemplateColumn.CellTemplate>
-                                                <DataTemplate x:DataType="models:ModModel">
-                                                    <Grid HorizontalAlignment="Center" VerticalAlignment="Center">
-                                                        <CheckBox
-                                                            Width="Auto"
-                                                            MinWidth="0"
-                                                            Command="{x:Bind ToggleModCommand}"
-                                                            IsChecked="{x:Bind IsEnabled, Mode=OneWay}"
-                                                            IsTabStop="False" />
-                                                    </Grid>
-                                                </DataTemplate>
-                                            </controls:DataGridTemplateColumn.CellTemplate>
-                                        </controls:DataGridTemplateColumn>
-
-
-                                        <controls:DataGridTemplateColumn
-                                            Width="SizeToCells"
-                                            MinWidth="0"
-                                            CanUserSort="False"
-                                            Header=""
-                                            IsReadOnly="True"
-                                            Tag="NotificationColumn">
-                                            <controls:DataGridTemplateColumn.CellTemplate>
-                                                <DataTemplate x:DataType="models:ModModel">
-
-                                                    <StackPanel
-                                                        HorizontalAlignment="Center"
-                                                        VerticalAlignment="Center"
-                                                        Orientation="Horizontal">
-                                                        <ItemsRepeater ItemsSource="{x:Bind ModNotifications, Mode=OneWay}">
-                                                            <ItemsRepeater.ItemTemplate>
-                                                                <DataTemplate x:DataType="notifications:ModNotification">
-                                                                    <Grid Margin="4,0" VerticalAlignment="Center">
-                                                                        <Button
-                                                                            Margin="0"
-                                                                            Padding="0"
-                                                                            BorderThickness="0"
-                                                                            Click="ButtonBase_OnClick"
-                                                                            CornerRadius="0"
-                                                                            DataContext="{x:Bind}"
-                                                                            PointerEntered="NotificationButton_OnPointerEntered"
-                                                                            PointerExited="NotificationButton_OnPointerExited">
-                                                                            <Button.Content>
-                                                                                <FontIcon
-                                                                                    VerticalAlignment="Bottom"
-                                                                                    Foreground="{ThemeResource AccentTextFillColorTertiaryBrush}"
-                                                                                    Glyph="{x:Bind AttentionType, Converter={StaticResource AttentionTypeToSymbolConverter}}" />
-                                                                            </Button.Content>
-                                                                        </Button>
-                                                                    </Grid>
-                                                                </DataTemplate>
-                                                            </ItemsRepeater.ItemTemplate>
-                                                        </ItemsRepeater>
-                                                    </StackPanel>
-
-                                                </DataTemplate>
-                                            </controls:DataGridTemplateColumn.CellTemplate>
-                                        </controls:DataGridTemplateColumn>
-
-                                        <controls:DataGridTemplateColumn
-                                            Width="SizeToCells"
-                                            CanUserSort="True"
-                                            Header="Mod Name"
-                                            IsReadOnly="True"
-                                            Tag="Name">
-                                            <controls:DataGridTemplateColumn.CellTemplate>
-                                                <DataTemplate x:DataType="models:ModModel">
-                                                    <Grid Margin="8,0">
-                                                        <TextBlock
-                                                            HorizontalAlignment="Stretch"
-                                                            VerticalAlignment="Center"
-                                                            DoubleTapped="ModNameCell_OnDoubleTapped"
-                                                            Text="{x:Bind Name, Mode=OneWay}" />
-                                                    </Grid>
-                                                </DataTemplate>
-                                            </controls:DataGridTemplateColumn.CellTemplate>
-                                        </controls:DataGridTemplateColumn>
-                                        <controls:DataGridTextColumn
-                                            Width="SizeToCells"
-                                            Binding="{Binding FolderName, Mode=OneWay}"
-                                            CanUserSort="True"
-                                            Header="Mod Folder Name"
-                                            IsReadOnly="True"
-                                            Tag="Folder Name" />
-
-                                        <controls:DataGridTextColumn
-                                            Width="SizeToCells"
-                                            Binding="{Binding Author, Mode=OneWay}"
-                                            CanUserSort="True"
-                                            Header="Author"
-                                            IsReadOnly="True"
-                                            Tag="Author Name" />
-
-                                        <controls:DataGridTemplateColumn
-                                            Width="SizeToCells"
-                                            CanUserSort="True"
-                                            Header="Date Added"
-                                            IsReadOnly="True"
-                                            Tag="Date Added">
-                                            <controls:DataGridTemplateColumn.CellTemplate>
-                                                <DataTemplate x:DataType="models:ModModel">
-                                                    <Grid
-                                                        Margin="8,0"
-                                                        HorizontalAlignment="Center"
-                                                        VerticalAlignment="Center">
-                                                        <TextBlock
-                                                            HorizontalAlignment="Stretch"
-                                                            VerticalAlignment="Center"
-                                                            Text="{x:Bind DateAdded, Mode=OneWay}" />
-                                                    </Grid>
-                                                </DataTemplate>
-                                            </controls:DataGridTemplateColumn.CellTemplate>
-                                        </controls:DataGridTemplateColumn>
-                                    </controls:DataGrid.Columns>
-
-                                </controls:DataGrid>
-                            </Grid>
-
-                            <Grid
-                                x:Name="ModDetailsPane"
-                                Grid.Column="1"
-                                Margin="0,0,0,8"
-                                Padding="5,5,5,5"
-                                Background="{ThemeResource ControlFillColorDefaultBrush}"
-                                CornerRadius="10">
-                                <Grid.RowDefinitions>
-                                    <RowDefinition Height="Auto" />
-                                    <RowDefinition Height="3*" />
-                                    <RowDefinition Height="Auto" />
-                                    <RowDefinition Height="Auto" />
-                                    <RowDefinition Height="Auto" />
-                                    <RowDefinition Height="*" />
-                                    <RowDefinition Height="Auto" />
-                                </Grid.RowDefinitions>
-                                <Grid Margin="0,0,0,8" VerticalAlignment="Top">
-                                    <Button
-                                        HorizontalAlignment="Right"
-                                        Content="Open In New Window"
-                                        IsEnabled="{x:Bind ViewModel.ModPaneVM.IsReadOnlyMode, Mode=OneWay, Converter={StaticResource BoolInverter}}"
-                                        ToolTipService.ToolTip="Set Mod preview image"
-                                        Visibility="Collapsed" />
-                                </Grid>
-                                <Grid
-                                    Grid.Row="1"
-                                    MinWidth="200"
-                                    MinHeight="200"
-                                    AllowDrop="True"
-                                    Background="{ThemeResource ControlFillColorTertiaryBrush}"
-                                    ContextFlyout="{Binding ElementName=ImageFlyout}"
-                                    CornerRadius="10"
-                                    DragEnter="ModDetailsPaneImage_OnDragEnter"
-                                    DragOver="ModDetailsPaneImage_OnDragOver"
-                                    Drop="ModDetailsPaneImage_OnDrop">
-                                    <Image ImageFailed="Image_OnImageFailed" Stretch="Uniform">
-                                        <Image.Source>
-                                            <BitmapImage CreateOptions="IgnoreImageCache" UriSource="{x:Bind ViewModel.ModPaneVM.SelectedModModel.ImagePath, Mode=OneWay}" />
-                                        </Image.Source>
-                                    </Image>
-                                    <Button
-                                        Margin="0,20,20,0"
-                                        HorizontalAlignment="Right"
-                                        VerticalAlignment="Top"
-                                        Command="{x:Bind ViewModel.ModPaneVM.SetImageUriCommand}"
-                                        IsEnabled="{x:Bind ViewModel.ModPaneVM.IsReadOnlyMode, Mode=OneWay, Converter={StaticResource BoolInverter}}">
-                                        <FontIcon Glyph="&#xE70F;" />
-                                    </Button>
-                                </Grid>
-                                <Grid Grid.Row="2">
-                                    <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="*" />
-                                        <ColumnDefinition Width="Auto" />
-                                    </Grid.ColumnDefinitions>
-                                    <controls1:EditableTextBlock
-                                        x:Name="ModNameTextBlock"
-                                        Margin="0,8"
-                                        HorizontalAlignment="Stretch"
-                                        IsEditMode="{x:Bind ViewModel.ModPaneVM.IsEditingModName, Mode=OneWay}"
-                                        Style="{ThemeResource SubtitleTextBlockStyle}"
-                                        TextAlignment="Center"
-                                        ToolTipService.ToolTip="Change mod display name"
-                                        Text="{x:Bind ViewModel.ModPaneVM.SelectedModModel.Name, Mode=TwoWay}" />
-
-                                    <SplitButton
-                                        Grid.Column="1"
-                                        Command="{x:Bind ViewModel.ModPaneVM.ToggleEditingModNameCommand}"
-                                        IsEnabled="{x:Bind ViewModel.ModPaneVM.IsReadOnlyMode, Mode=OneWay, Converter={StaticResource BoolInverter}}">
-                                        <FontIcon Glyph="&#xE70F;" />
-                                        <SplitButton.Flyout>
-                                            <MenuFlyout Placement="Bottom">
-                                                <MenuFlyoutItem
-                                                    Command="{x:Bind ViewModel.ModPaneVM.SetModIniFileCommand}"
-                                                    ToolTipService.ToolTip="Set the mod .ini file to be read by JASM"
-                                                    Text="Set mod .ini file" />
-                                                <MenuFlyoutItem
-                                                    Command="{x:Bind ViewModel.ModPaneVM.ClearSetModIniFileCommand}"
-                                                    Icon="Clear"
-                                                    ToolTipService.ToolTip="JASM will not look for merged.ini/Script.ini file and ignore keyswaps for this mod"
-                                                    Text="Ignore .ini file for this mod" />
-                                            </MenuFlyout>
-                                        </SplitButton.Flyout>
-
-                                    </SplitButton>
-                                </Grid>
-
-                                <Grid Grid.Row="3">
-                                    <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="*" />
-                                        <ColumnDefinition Width="Auto" />
-                                    </Grid.ColumnDefinitions>
-                                    <TextBox
-                                        VerticalAlignment="Center"
-                                        Header="Mod Url:"
-                                        IsEnabled="{x:Bind ViewModel.ModPaneVM.IsReadOnlyMode, Mode=OneWay, Converter={StaticResource BoolInverter}}"
-                                        Text="{x:Bind ViewModel.ModPaneVM.SelectedModModel.ModUrl, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-
-                                    <HyperlinkButton
-                                        Grid.Column="1"
-                                        VerticalAlignment="Bottom"
-                                        IsEnabled="{x:Bind ViewModel.ModPaneVM.IsReadOnlyMode, Mode=OneWay, Converter={StaticResource BoolInverter}}"
-                                        NavigateUri="{x:Bind ViewModel.ModPaneVM.SelectedModModel.ModUrl, Mode=OneWay, Converter={StaticResource StringToUri}}">
-                                        <FontIcon FontSize="18" Glyph="&#xE8A7;" />
-                                    </HyperlinkButton>
-
-                                </Grid>
-
-
-                                <StackPanel Grid.Row="4" Orientation="Horizontal">
-                                    <TextBlock Visibility="Collapsed" Text="Latest Version:" />
-                                    <TextBlock Text="{x:Bind ViewModel.ModPaneVM.SelectedModModel.ModUrl}" />
-
-                                </StackPanel>
-
-                                <ScrollViewer
-                                    Grid.Row="5"
-                                    Margin="0,12,0,0"
-                                    Padding="0,0,14,0"
-                                    VerticalScrollBarVisibility="Auto">
-
-                                    <controls:SwitchPresenter Value="{x:Bind ViewModel.ModPaneVM.ShowKeySwapSection, Mode=OneWay}">
-                                        <controls:Case Value="true">
-                                            <StackPanel>
-                                                <ItemsRepeater ItemsSource="{x:Bind ViewModel.ModPaneVM.SelectedModModel.SkinModKeySwaps, Mode=OneWay}">
-                                                    <ItemsRepeater.ItemTemplate>
-                                                        <DataTemplate x:DataType="models:SkinModKeySwapModel">
-                                                            <Grid Margin="0,0">
-                                                                <Grid.ColumnDefinitions>
-                                                                    <ColumnDefinition Width="*" />
-                                                                    <ColumnDefinition Width="*" />
-                                                                    <ColumnDefinition Width="*" />
-                                                                </Grid.ColumnDefinitions>
-                                                                <TextBox
-                                                                    MinWidth="100"
-                                                                    HorizontalAlignment="Left"
-                                                                    Header="Forward Key"
-                                                                    Text="{x:Bind ForwardHotkey, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-
-                                                                <StackPanel Grid.Column="1" VerticalAlignment="Center">
-                                                                    <TextBlock HorizontalAlignment="Center" Text="{x:Bind SectionKey}" />
-                                                                    <StackPanel HorizontalAlignment="Center" Orientation="Horizontal">
-                                                                        <TextBlock Margin="0,0,4,0" Text="Variations: " />
-                                                                        <TextBlock Text="{x:Bind VariationsCount, Mode=OneWay}" />
-                                                                    </StackPanel>
-                                                                </StackPanel>
-                                                                <TextBox
-                                                                    Grid.Column="2"
-                                                                    MinWidth="100"
-                                                                    HorizontalAlignment="Right"
-                                                                    Header="Backward Key"
-                                                                    Text="{x:Bind BackwardHotkey, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-                                                            </Grid>
-                                                        </DataTemplate>
-                                                    </ItemsRepeater.ItemTemplate>
-                                                </ItemsRepeater>
-
-                                            </StackPanel>
-                                        </controls:Case>
-
-                                        <controls:Case Value="false">
-                                            <TextBlock
-                                                HorizontalAlignment="Center"
-                                                VerticalAlignment="Top"
-                                                TextWrapping="WrapWholeWords"
-                                                Text="Key swap management is disabled for this mod" />
-
-                                        </controls:Case>
-                                    </controls:SwitchPresenter>
-
-
-
-                                </ScrollViewer>
-                                <Grid Grid.Row="6" Padding="0,12">
-                                    <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="Auto" />
-                                        <ColumnDefinition />
-                                        <ColumnDefinition Width="Auto" />
-                                    </Grid.ColumnDefinitions>
-                                    <Button
-                                        Background="{ThemeResource SystemFillColorAttentionBrush}"
-                                        Command="{x:Bind ViewModel.ModPaneVM.SaveModSettingsCommand}"
-                                        IsEnabled="{x:Bind ViewModel.ModPaneVM.IsReadOnlyMode, Mode=OneWay, Converter={StaticResource BoolInverter}}">
-                                        <Button.Content>
-                                            <StackPanel Orientation="Horizontal">
-                                                <FontIcon Margin="0,0,4,0" Glyph="&#xE74E;" />
-                                                <TextBlock Text="Save" />
-                                            </StackPanel>
-                                        </Button.Content>
-                                        <Button.KeyboardAccelerators>
-                                            <KeyboardAccelerator Key="S" Modifiers="Control" />
-                                        </Button.KeyboardAccelerators>
-
-                                    </Button>
-
-                                    <Grid Grid.Column="1" Visibility="{x:Bind ViewModel.ModPaneVM.SelectedModModel.IsEnabled, Mode=OneWay}">
-
-                                        <Grid.ColumnDefinitions>
-                                            <ColumnDefinition Width="*" />
-                                            <ColumnDefinition Width="Auto" />
-                                            <ColumnDefinition Width="*" />
-                                        </Grid.ColumnDefinitions>
-
-                                        <Border
-                                            Grid.Column="1"
-                                            Background="{ThemeResource AccentFillColorSelectedTextBackgroundBrush}"
-                                            CornerRadius="10">
-                                            <TextBlock
-                                                Padding="4,0"
-                                                HorizontalAlignment="Center"
-                                                VerticalAlignment="Center"
-                                                Text="Mod Enabled" />
-                                        </Border>
-
-                                    </Grid>
-
-
-                                    <Button
-                                        Grid.Column="2"
-                                        HorizontalAlignment="Right"
-                                        Command="{x:Bind ViewModel.ModPaneVM.OpenModFolderCommand}"
-                                        Content="Open Mod Folder..."
-                                        IsEnabled="{x:Bind ViewModel.ModPaneVM.IsReadOnlyMode, Mode=OneWay, Converter={StaticResource BoolInverter}}" />
-                                </Grid>
-                            </Grid>
-                            <controls:GridSplitter
-                                x:Name="ModPaneSplitter"
-                                Grid.Column="1"
-                                Width="8"
-                                Height="40"
-                                HorizontalAlignment="Left"
-                                ResizeBehavior="BasedOnAlignment"
-                                ResizeDirection="Auto">
-                                <controls:GridSplitter.RenderTransform>
-                                    <TranslateTransform X="-10" />
-                                </controls:GridSplitter.RenderTransform>
-                            </controls:GridSplitter>
+                        <Grid MinWidth="32">
+                            <ProgressRing IsActive="{x:Bind ViewModel.IsAddingModFolder, Mode=OneWay}" />
                         </Grid>
-                    </Grid>
 
+                    </StackPanel>
 
                 </Grid>
+                <Grid
+                    x:Name="MainContentArea"
+                    Grid.Row="1"
+                    AllowDrop="False"
+                    Background="Transparent"
+                    DragOver="ModListArea_OnDragOver"
+                    Drop="ModListArea_OnDrop">
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="7*" />
+                            <ColumnDefinition Width="3*" />
+                        </Grid.ColumnDefinitions>
+                        <Grid
+                            x:Name="ModListArea"
+                            AllowDrop="True"
+                            Background="Transparent"
+                            CornerRadius="10"
+                            DragOver="ModListArea_OnDragOver"
+                            Drop="ModListArea_OnDrop">
+                            <controls:DataGrid
+                                x:Name="ModListGrid"
+                                AllowDrop="False"
+                                AutoGenerateColumns="False"
+                                CanUserReorderColumns="False"
+                                CanUserResizeColumns="True"
+                                CellEditEnded="ModListGrid_OnCellEditEnded"
+                                ContextFlyout="{Binding ElementName=ModRowFlyout}"
+                                FrozenColumnCount="3"
+                                GridLinesVisibility="All"
+                                ItemsSource="{x:Bind ViewModel.ModListVM.Mods, Mode=OneWay}"
+                                KeyDown="ModListGrid_OnKeyDown"
+                                SelectionChanged="ModListGrid_OnSelectionChanged"
+                                SelectionMode="Extended"
+                                Sorting="ModListGrid_OnSorting">
+                                <controls:DataGrid.Columns>
+                                    <controls:DataGridTemplateColumn
+                                        Width="SizeToHeader"
+                                        CanUserResize="False"
+                                        CanUserSort="True"
+                                        Header="Enabled"
+                                        Tag="IsEnabled">
+
+                                        <controls:DataGridTemplateColumn.CellTemplate>
+                                            <DataTemplate x:DataType="models:ModModel">
+                                                <Grid HorizontalAlignment="Center" VerticalAlignment="Center">
+                                                    <CheckBox
+                                                        Command="{x:Bind ToggleModCommand}"
+                                                        IsChecked="{x:Bind IsEnabled, Mode=OneWay}"
+                                                        IsTabStop="False"
+                                                        Width="Auto"
+                                                        MinWidth="0"
+                                                        />
+                                                </Grid>
+                                            </DataTemplate>
+                                        </controls:DataGridTemplateColumn.CellTemplate>
+                                    </controls:DataGridTemplateColumn>
+
+
+                                    <controls:DataGridTemplateColumn
+                                        Width="SizeToCells"
+                                        CanUserSort="False"
+                                        Header=""
+                                        IsReadOnly="True"
+                                        Tag="NotificationColumn"
+                                        MinWidth="0">
+                                        <controls:DataGridTemplateColumn.CellTemplate>
+                                            <DataTemplate x:DataType="models:ModModel">
+
+                                                <StackPanel
+                                                    HorizontalAlignment="Center"
+                                                    VerticalAlignment="Center"
+                                                    Orientation="Horizontal">
+                                                    <ItemsRepeater ItemsSource="{x:Bind ModNotifications, Mode=OneWay}">
+                                                        <ItemsRepeater.ItemTemplate>
+                                                            <DataTemplate x:DataType="notifications:ModNotification">
+                                                                <Grid Margin="4,0" VerticalAlignment="Center">
+                                                                    <Button
+                                                                        Margin="0"
+                                                                        Padding="0"
+                                                                        BorderThickness="0"
+                                                                        Click="ButtonBase_OnClick"
+                                                                        CornerRadius="0"
+                                                                        DataContext="{x:Bind}"
+                                                                        PointerEntered="NotificationButton_OnPointerEntered"
+                                                                        PointerExited="NotificationButton_OnPointerExited">
+                                                                        <Button.Content>
+                                                                            <FontIcon
+                                                                                VerticalAlignment="Bottom"
+                                                                                Foreground="{ThemeResource AccentTextFillColorTertiaryBrush}"
+                                                                                Glyph="{x:Bind AttentionType, Converter={StaticResource AttentionTypeToSymbolConverter}}" />
+                                                                        </Button.Content>
+                                                                    </Button>
+                                                                </Grid>
+                                                            </DataTemplate>
+                                                        </ItemsRepeater.ItemTemplate>
+                                                    </ItemsRepeater>
+                                                </StackPanel>
+
+                                            </DataTemplate>
+                                        </controls:DataGridTemplateColumn.CellTemplate>
+                                    </controls:DataGridTemplateColumn>
+
+                                    <controls:DataGridTemplateColumn
+                                        Width="SizeToCells"
+                                        CanUserSort="True"
+                                        Header="Mod Name"
+                                        IsReadOnly="True"
+                                        Tag="Name">
+                                        <controls:DataGridTemplateColumn.CellTemplate>
+                                            <DataTemplate x:DataType="models:ModModel">
+                                                <Grid Margin="8,0">
+                                                    <TextBlock
+                                                        HorizontalAlignment="Stretch"
+                                                        VerticalAlignment="Center"
+                                                        DoubleTapped="ModNameCell_OnDoubleTapped"
+                                                        Text="{x:Bind Name, Mode=OneWay}" />
+                                                </Grid>
+                                            </DataTemplate>
+                                        </controls:DataGridTemplateColumn.CellTemplate>
+                                    </controls:DataGridTemplateColumn>
+                                    <controls:DataGridTextColumn
+                                        Width="SizeToCells"
+                                        Binding="{Binding FolderName, Mode=OneWay}"
+                                        CanUserSort="True"
+                                        Header="Mod Folder Name"
+                                        IsReadOnly="True"
+                                        Tag="Folder Name" />
+
+                                    <controls:DataGridTextColumn
+                                        Width="SizeToCells"
+                                        Binding="{Binding Author, Mode=OneWay}"
+                                        CanUserSort="True"
+                                        Header="Author"
+                                        IsReadOnly="True"
+                                        Tag="Author Name" />
+
+                                    <controls:DataGridTemplateColumn
+                                        Width="SizeToCells"
+                                        CanUserSort="True"
+                                        Header="Date Added"
+                                        IsReadOnly="True"
+                                        Tag="Date Added">
+                                        <controls:DataGridTemplateColumn.CellTemplate>
+                                            <DataTemplate x:DataType="models:ModModel">
+                                                <Grid
+                                                    Margin="8,0"
+                                                    HorizontalAlignment="Center"
+                                                    VerticalAlignment="Center">
+                                                    <TextBlock
+                                                        HorizontalAlignment="Stretch"
+                                                        VerticalAlignment="Center"
+                                                        Text="{x:Bind DateAdded, Mode=OneWay}" />
+                                                </Grid>
+                                            </DataTemplate>
+                                        </controls:DataGridTemplateColumn.CellTemplate>
+                                    </controls:DataGridTemplateColumn>
+                                </controls:DataGrid.Columns>
+
+                            </controls:DataGrid>
+                        </Grid>
+
+                        <Grid
+                            x:Name="ModDetailsPane"
+                            Grid.Column="1"
+                            Margin="0,0,0,8"
+                            Padding="5,5,5,5"
+                            Background="{ThemeResource ControlFillColorDefaultBrush}"
+                            CornerRadius="10">
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="3*" />
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="*" />
+                                <RowDefinition Height="Auto" />
+                            </Grid.RowDefinitions>
+                            <Grid Margin="0,0,0,8" VerticalAlignment="Top">
+                                <Button
+                                    HorizontalAlignment="Right"
+                                    Content="Open In New Window"
+                                    IsEnabled="{x:Bind ViewModel.ModPaneVM.IsReadOnlyMode, Mode=OneWay, Converter={StaticResource BoolInverter}}"
+                                    ToolTipService.ToolTip="Set Mod preview image"
+                                    Visibility="Collapsed" />
+                            </Grid>
+                            <Grid
+                                Grid.Row="1"
+                                MinWidth="200"
+                                MinHeight="200"
+                                AllowDrop="True"
+                                Background="{ThemeResource ControlFillColorTertiaryBrush}"
+                                ContextFlyout="{Binding ElementName=ImageFlyout}"
+                                CornerRadius="10"
+                                DragEnter="ModDetailsPaneImage_OnDragEnter"
+                                DragOver="ModDetailsPaneImage_OnDragOver"
+                                Drop="ModDetailsPaneImage_OnDrop">
+                                <Image ImageFailed="Image_OnImageFailed" Stretch="Uniform">
+                                    <Image.Source>
+                                        <BitmapImage CreateOptions="IgnoreImageCache" UriSource="{x:Bind ViewModel.ModPaneVM.SelectedModModel.ImagePath, Mode=OneWay}" />
+                                    </Image.Source>
+                                </Image>
+                                <Button
+                                    Margin="0,20,20,0"
+                                    HorizontalAlignment="Right"
+                                    VerticalAlignment="Top"
+                                    Command="{x:Bind ViewModel.ModPaneVM.SetImageUriCommand}"
+                                    IsEnabled="{x:Bind ViewModel.ModPaneVM.IsReadOnlyMode, Mode=OneWay, Converter={StaticResource BoolInverter}}">
+                                    <FontIcon Glyph="&#xE70F;" />
+                                </Button>
+                            </Grid>
+                            <Grid Grid.Row="2">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*" />
+                                    <ColumnDefinition Width="Auto" />
+                                </Grid.ColumnDefinitions>
+                                <controls1:EditableTextBlock
+                                    x:Name="ModNameTextBlock"
+                                    Margin="0,8"
+                                    HorizontalAlignment="Stretch"
+                                    IsEditMode="{x:Bind ViewModel.ModPaneVM.IsEditingModName, Mode=OneWay}"
+                                    Style="{ThemeResource SubtitleTextBlockStyle}"
+                                    TextAlignment="Center"
+                                    ToolTipService.ToolTip="Change mod display name"
+                                    Text="{x:Bind ViewModel.ModPaneVM.SelectedModModel.Name, Mode=TwoWay}" />
+
+                                <SplitButton
+                                    Grid.Column="1"
+                                    Command="{x:Bind ViewModel.ModPaneVM.ToggleEditingModNameCommand}"
+                                    IsEnabled="{x:Bind ViewModel.ModPaneVM.IsReadOnlyMode, Mode=OneWay, Converter={StaticResource BoolInverter}}">
+                                    <FontIcon Glyph="&#xE70F;" />
+                                    <SplitButton.Flyout>
+                                        <MenuFlyout Placement="Bottom">
+                                            <MenuFlyoutItem
+                                                Command="{x:Bind ViewModel.ModPaneVM.SetModIniFileCommand}"
+                                                ToolTipService.ToolTip="Set the mod .ini file to be read by JASM"
+                                                Text="Set mod .ini file" />
+                                            <MenuFlyoutItem
+                                                Command="{x:Bind ViewModel.ModPaneVM.ClearSetModIniFileCommand}"
+                                                Icon="Clear"
+                                                ToolTipService.ToolTip="JASM will not look for merged.ini/Script.ini file and ignore keyswaps for this mod"
+                                                Text="Ignore .ini file for this mod" />
+                                        </MenuFlyout>
+                                    </SplitButton.Flyout>
+
+                                </SplitButton>
+                            </Grid>
+
+                            <Grid Grid.Row="3">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*" />
+                                    <ColumnDefinition Width="Auto" />
+                                </Grid.ColumnDefinitions>
+                                <TextBox
+                                    VerticalAlignment="Center"
+                                    Header="Mod Url:"
+                                    IsEnabled="{x:Bind ViewModel.ModPaneVM.IsReadOnlyMode, Mode=OneWay, Converter={StaticResource BoolInverter}}"
+                                    Text="{x:Bind ViewModel.ModPaneVM.SelectedModModel.ModUrl, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+
+                                <HyperlinkButton
+                                    Grid.Column="1"
+                                    VerticalAlignment="Bottom"
+                                    IsEnabled="{x:Bind ViewModel.ModPaneVM.IsReadOnlyMode, Mode=OneWay, Converter={StaticResource BoolInverter}}"
+                                    NavigateUri="{x:Bind ViewModel.ModPaneVM.SelectedModModel.ModUrl, Mode=OneWay, Converter={StaticResource StringToUri}}">
+                                    <FontIcon FontSize="18" Glyph="&#xE8A7;" />
+                                </HyperlinkButton>
+
+                            </Grid>
+
+
+                            <StackPanel Grid.Row="4" Orientation="Horizontal">
+                                <TextBlock Visibility="Collapsed" Text="Latest Version:" />
+                                <TextBlock Text="{x:Bind ViewModel.ModPaneVM.SelectedModModel.ModUrl}" />
+
+                            </StackPanel>
+
+                            <ScrollViewer
+                                Grid.Row="5"
+                                Margin="0,12,0,0"
+                                Padding="0,0,14,0"
+                                VerticalScrollBarVisibility="Auto">
+
+                                <controls:SwitchPresenter Value="{x:Bind ViewModel.ModPaneVM.ShowKeySwapSection, Mode=OneWay}">
+                                    <controls:Case Value="true">
+                                        <StackPanel>
+                                            <ItemsRepeater ItemsSource="{x:Bind ViewModel.ModPaneVM.SelectedModModel.SkinModKeySwaps, Mode=OneWay}">
+                                                <ItemsRepeater.ItemTemplate>
+                                                    <DataTemplate x:DataType="models:SkinModKeySwapModel">
+                                                        <Grid Margin="0,0">
+                                                            <Grid.ColumnDefinitions>
+                                                                <ColumnDefinition Width="*" />
+                                                                <ColumnDefinition Width="*" />
+                                                                <ColumnDefinition Width="*" />
+                                                            </Grid.ColumnDefinitions>
+                                                            <TextBox
+                                                                MinWidth="100"
+                                                                HorizontalAlignment="Left"
+                                                                Header="Forward Key"
+                                                                Text="{x:Bind ForwardHotkey, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+
+                                                            <StackPanel Grid.Column="1" VerticalAlignment="Center">
+                                                                <TextBlock HorizontalAlignment="Center" Text="{x:Bind SectionKey}" />
+                                                                <StackPanel HorizontalAlignment="Center" Orientation="Horizontal">
+                                                                    <TextBlock Margin="0,0,4,0" Text="Variations: " />
+                                                                    <TextBlock Text="{x:Bind VariationsCount, Mode=OneWay}" />
+                                                                </StackPanel>
+                                                            </StackPanel>
+                                                            <TextBox
+                                                                Grid.Column="2"
+                                                                MinWidth="100"
+                                                                HorizontalAlignment="Right"
+                                                                Header="Backward Key"
+                                                                Text="{x:Bind BackwardHotkey, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                                                        </Grid>
+                                                    </DataTemplate>
+                                                </ItemsRepeater.ItemTemplate>
+                                            </ItemsRepeater>
+
+                                        </StackPanel>
+                                    </controls:Case>
+
+                                    <controls:Case Value="false">
+                                        <TextBlock
+                                            HorizontalAlignment="Center"
+                                            VerticalAlignment="Top"
+                                            TextWrapping="WrapWholeWords"
+                                            Text="Key swap management is disabled for this mod" />
+
+                                    </controls:Case>
+                                </controls:SwitchPresenter>
+
+
+
+                            </ScrollViewer>
+                            <Grid Grid.Row="6" Padding="0,12">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition />
+                                    <ColumnDefinition Width="Auto" />
+                                </Grid.ColumnDefinitions>
+                                <Button
+                                    Background="{ThemeResource SystemFillColorAttentionBrush}"
+                                    Command="{x:Bind ViewModel.ModPaneVM.SaveModSettingsCommand}"
+                                    IsEnabled="{x:Bind ViewModel.ModPaneVM.IsReadOnlyMode, Mode=OneWay, Converter={StaticResource BoolInverter}}">
+                                    <Button.Content>
+                                        <StackPanel Orientation="Horizontal">
+                                            <FontIcon Margin="0,0,4,0" Glyph="&#xE74E;" />
+                                            <TextBlock Text="Save" />
+                                        </StackPanel>
+                                    </Button.Content>
+                                    <Button.KeyboardAccelerators>
+                                        <KeyboardAccelerator Key="S" Modifiers="Control" />
+                                    </Button.KeyboardAccelerators>
+
+                                </Button>
+
+                                <Grid Grid.Column="1" Visibility="{x:Bind ViewModel.ModPaneVM.SelectedModModel.IsEnabled, Mode=OneWay}">
+
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="*" />
+                                        <ColumnDefinition Width="Auto" />
+                                        <ColumnDefinition Width="*" />
+                                    </Grid.ColumnDefinitions>
+
+                                    <Border
+                                        Grid.Column="1"
+                                        Background="{ThemeResource AccentFillColorSelectedTextBackgroundBrush}"
+                                        CornerRadius="10">
+                                        <TextBlock
+                                            Padding="4,0"
+                                            HorizontalAlignment="Center"
+                                            VerticalAlignment="Center"
+                                            Text="Mod Enabled" />
+                                    </Border>
+
+                                </Grid>
+
+
+                                <Button
+                                    Grid.Column="2"
+                                    HorizontalAlignment="Right"
+                                    Command="{x:Bind ViewModel.ModPaneVM.OpenModFolderCommand}"
+                                    Content="Open Mod Folder..."
+                                    IsEnabled="{x:Bind ViewModel.ModPaneVM.IsReadOnlyMode, Mode=OneWay, Converter={StaticResource BoolInverter}}" />
+                            </Grid>
+                        </Grid>
+                        <controls:GridSplitter
+                            x:Name="ModPaneSplitter"
+                            Grid.Column="1"
+                            Width="8"
+                            Height="40"
+                            HorizontalAlignment="Left"
+                            ResizeBehavior="BasedOnAlignment"
+                            ResizeDirection="Auto">
+                            <controls:GridSplitter.RenderTransform>
+                                <TranslateTransform X="-10" />
+                            </controls:GridSplitter.RenderTransform>
+                        </controls:GridSplitter>
+                    </Grid>
+                </Grid>
+
+
             </Grid>
 
         </Grid>

--- a/src/GIMI-ModManager.WinUI/Views/CharacterDetailsPage.xaml
+++ b/src/GIMI-ModManager.WinUI/Views/CharacterDetailsPage.xaml
@@ -307,486 +307,500 @@
                     Content="Disable All Mods" />
             </Grid>
 
+            <Grid Grid.Column="1" Visibility="{x:Bind ViewModel.IsFullPageLoaderVisible, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}">
+                <StackPanel
+                    HorizontalAlignment="Center"
+                    VerticalAlignment="Center"
+                    Spacing="16">
+                    <ProgressRing
+                        Width="50"
+                        Height="50"
+                        IsActive="True"
+                        IsIndeterminate="True" />
+                    <TextBlock Text="Loading..." />
+                </StackPanel>
+            </Grid>
 
-            <Grid Grid.Column="1" Margin="4,0,4,0">
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition />
-                </Grid.RowDefinitions>
+            <Grid Grid.Column="1" Visibility="{x:Bind ViewModel.IsFullPagerLoaderHidden, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}">
+                <Grid Margin="4,0,4,0">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition />
+                    </Grid.RowDefinitions>
 
-                <Grid Margin="0,0,0,8">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition />
-                        <ColumnDefinition />
-                    </Grid.ColumnDefinitions>
-
-                    <StackPanel Orientation="Horizontal">
-                        <MenuBar>
-                            <MenuBarItem Title="Mods">
-                                <MenuBarItem.Items>
-                                    <MenuFlyoutItem
-                                        Command="{x:Bind ViewModel.AddModFolderCommand}"
-                                        ToolTipService.ToolTip="Add a mod folder"
-                                        Text="Add Mod..." />
-
-                                    <MenuFlyoutItem
-                                        Command="{x:Bind ViewModel.AddModArchiveCommand}"
-                                        ToolTipService.ToolTip="Add a mod inside a compressed archive"
-                                        Text="Add Archive...">
-                                        <MenuFlyoutItem.KeyboardAccelerators>
-                                            <KeyboardAccelerator Key="O" Modifiers="Control" />
-                                        </MenuFlyoutItem.KeyboardAccelerators>
-                                    </MenuFlyoutItem>
-
-                                    <MenuFlyoutSeparator />
-                                    <MenuFlyoutItem Command="{x:Bind ViewModel.RefreshModsCommand}" Text="Refresh Mods">
-                                        <MenuFlyoutItem.KeyboardAccelerators>
-                                            <KeyboardAccelerator Key="F5" />
-                                        </MenuFlyoutItem.KeyboardAccelerators>
-                                    </MenuFlyoutItem>
-                                </MenuBarItem.Items>
-                            </MenuBarItem>
-
-                            <MenuBarItem Title="Folders">
-                                <MenuFlyoutItem Command="{x:Bind ViewModel.OpenModsFolderCommand}" Text="Open Character's Mod folder..." />
-                                <MenuFlyoutSeparator />
-                                <MenuFlyoutItem Command="{x:Bind ViewModel.OpenGIMIRootFolderCommand}" Text="Open 3Dmigoto Root folder..." />
-                            </MenuBarItem>
-                        </MenuBar>
-
-                    </StackPanel>
-
-                    <StackPanel
-                        Grid.Column="1"
-                        HorizontalAlignment="Right"
-                        VerticalAlignment="Center"
-                        Orientation="Horizontal"
-                        Spacing="16">
-
-                        <InfoBar
-                            Height="50"
-                            VerticalAlignment="Center"
-                            IsClosable="False"
-                            IsOpen="{x:Bind ViewModel.ModListVM.IsInfoBarOpen, Mode=OneWay}"
-                            Message="{x:Bind ViewModel.ModListVM.InfoBarMessage, Mode=OneWay}"
-                            Severity="{x:Bind ViewModel.ModListVM.Severity, Mode=OneWay}"
-                            Visibility="Visible" />
-
-                        <ToggleSwitch
-                            x:Name="ViewToggleSwitch"
-                            IsOn="False"
-                            OffContent="Detailed View"
-                            OnContent="Gallery View"
-                            Toggled="ViewToggleSwitch_OnToggled" />
-
-                        <Grid MinWidth="32">
-                            <ProgressRing IsActive="{x:Bind ViewModel.IsAddingModFolder, Mode=OneWay}" />
-                        </Grid>
-
-                    </StackPanel>
-
-                </Grid>
-                <Grid
-                    x:Name="MainContentArea"
-                    Grid.Row="1"
-                    AllowDrop="False"
-                    Background="Transparent"
-                    DragOver="ModListArea_OnDragOver"
-                    Drop="ModListArea_OnDrop">
-                    <Grid>
+                    <Grid Margin="0,0,0,8">
                         <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="7*" />
-                            <ColumnDefinition Width="3*" />
+                            <ColumnDefinition />
+                            <ColumnDefinition />
                         </Grid.ColumnDefinitions>
-                        <Grid
-                            x:Name="ModListArea"
-                            AllowDrop="True"
-                            Background="Transparent"
-                            CornerRadius="10"
-                            DragOver="ModListArea_OnDragOver"
-                            Drop="ModListArea_OnDrop">
-                            <controls:DataGrid
-                                x:Name="ModListGrid"
-                                AllowDrop="False"
-                                AutoGenerateColumns="False"
-                                CanUserReorderColumns="False"
-                                CanUserResizeColumns="True"
-                                CellEditEnded="ModListGrid_OnCellEditEnded"
-                                ContextFlyout="{Binding ElementName=ModRowFlyout}"
-                                FrozenColumnCount="3"
-                                GridLinesVisibility="All"
-                                ItemsSource="{x:Bind ViewModel.ModListVM.Mods, Mode=OneWay}"
-                                KeyDown="ModListGrid_OnKeyDown"
-                                SelectionChanged="ModListGrid_OnSelectionChanged"
-                                SelectionMode="Extended"
-                                Sorting="ModListGrid_OnSorting">
-                                <controls:DataGrid.Columns>
-                                    <controls:DataGridTemplateColumn
-                                        Width="SizeToHeader"
-                                        CanUserResize="False"
-                                        CanUserSort="True"
-                                        Header="Enabled"
-                                        Tag="IsEnabled">
 
-                                        <controls:DataGridTemplateColumn.CellTemplate>
-                                            <DataTemplate x:DataType="models:ModModel">
-                                                <Grid HorizontalAlignment="Center" VerticalAlignment="Center">
-                                                    <CheckBox
-                                                        Command="{x:Bind ToggleModCommand}"
-                                                        IsChecked="{x:Bind IsEnabled, Mode=OneWay}"
-                                                        IsTabStop="False"
-                                                        Width="Auto"
-                                                        MinWidth="0"
-                                                        />
-                                                </Grid>
-                                            </DataTemplate>
-                                        </controls:DataGridTemplateColumn.CellTemplate>
-                                    </controls:DataGridTemplateColumn>
+                        <StackPanel Orientation="Horizontal">
+                            <MenuBar>
+                                <MenuBarItem Title="Mods">
+                                    <MenuBarItem.Items>
+                                        <MenuFlyoutItem
+                                            Command="{x:Bind ViewModel.AddModFolderCommand}"
+                                            ToolTipService.ToolTip="Add a mod folder"
+                                            Text="Add Mod..." />
 
+                                        <MenuFlyoutItem
+                                            Command="{x:Bind ViewModel.AddModArchiveCommand}"
+                                            ToolTipService.ToolTip="Add a mod inside a compressed archive"
+                                            Text="Add Archive...">
+                                            <MenuFlyoutItem.KeyboardAccelerators>
+                                                <KeyboardAccelerator Key="O" Modifiers="Control" />
+                                            </MenuFlyoutItem.KeyboardAccelerators>
+                                        </MenuFlyoutItem>
 
-                                    <controls:DataGridTemplateColumn
-                                        Width="SizeToCells"
-                                        CanUserSort="False"
-                                        Header=""
-                                        IsReadOnly="True"
-                                        Tag="NotificationColumn"
-                                        MinWidth="0">
-                                        <controls:DataGridTemplateColumn.CellTemplate>
-                                            <DataTemplate x:DataType="models:ModModel">
+                                        <MenuFlyoutSeparator />
+                                        <MenuFlyoutItem Command="{x:Bind ViewModel.RefreshModsCommand}" Text="Refresh Mods">
+                                            <MenuFlyoutItem.KeyboardAccelerators>
+                                                <KeyboardAccelerator Key="F5" />
+                                            </MenuFlyoutItem.KeyboardAccelerators>
+                                        </MenuFlyoutItem>
+                                    </MenuBarItem.Items>
+                                </MenuBarItem>
 
-                                                <StackPanel
-                                                    HorizontalAlignment="Center"
-                                                    VerticalAlignment="Center"
-                                                    Orientation="Horizontal">
-                                                    <ItemsRepeater ItemsSource="{x:Bind ModNotifications, Mode=OneWay}">
-                                                        <ItemsRepeater.ItemTemplate>
-                                                            <DataTemplate x:DataType="notifications:ModNotification">
-                                                                <Grid Margin="4,0" VerticalAlignment="Center">
-                                                                    <Button
-                                                                        Margin="0"
-                                                                        Padding="0"
-                                                                        BorderThickness="0"
-                                                                        Click="ButtonBase_OnClick"
-                                                                        CornerRadius="0"
-                                                                        DataContext="{x:Bind}"
-                                                                        PointerEntered="NotificationButton_OnPointerEntered"
-                                                                        PointerExited="NotificationButton_OnPointerExited">
-                                                                        <Button.Content>
-                                                                            <FontIcon
-                                                                                VerticalAlignment="Bottom"
-                                                                                Foreground="{ThemeResource AccentTextFillColorTertiaryBrush}"
-                                                                                Glyph="{x:Bind AttentionType, Converter={StaticResource AttentionTypeToSymbolConverter}}" />
-                                                                        </Button.Content>
-                                                                    </Button>
-                                                                </Grid>
-                                                            </DataTemplate>
-                                                        </ItemsRepeater.ItemTemplate>
-                                                    </ItemsRepeater>
-                                                </StackPanel>
+                                <MenuBarItem Title="Folders">
+                                    <MenuFlyoutItem Command="{x:Bind ViewModel.OpenModsFolderCommand}" Text="Open Character's Mod folder..." />
+                                    <MenuFlyoutSeparator />
+                                    <MenuFlyoutItem Command="{x:Bind ViewModel.OpenGIMIRootFolderCommand}" Text="Open 3Dmigoto Root folder..." />
+                                </MenuBarItem>
+                            </MenuBar>
 
-                                            </DataTemplate>
-                                        </controls:DataGridTemplateColumn.CellTemplate>
-                                    </controls:DataGridTemplateColumn>
+                        </StackPanel>
 
-                                    <controls:DataGridTemplateColumn
-                                        Width="SizeToCells"
-                                        CanUserSort="True"
-                                        Header="Mod Name"
-                                        IsReadOnly="True"
-                                        Tag="Name">
-                                        <controls:DataGridTemplateColumn.CellTemplate>
-                                            <DataTemplate x:DataType="models:ModModel">
-                                                <Grid Margin="8,0">
-                                                    <TextBlock
-                                                        HorizontalAlignment="Stretch"
-                                                        VerticalAlignment="Center"
-                                                        DoubleTapped="ModNameCell_OnDoubleTapped"
-                                                        Text="{x:Bind Name, Mode=OneWay}" />
-                                                </Grid>
-                                            </DataTemplate>
-                                        </controls:DataGridTemplateColumn.CellTemplate>
-                                    </controls:DataGridTemplateColumn>
-                                    <controls:DataGridTextColumn
-                                        Width="SizeToCells"
-                                        Binding="{Binding FolderName, Mode=OneWay}"
-                                        CanUserSort="True"
-                                        Header="Mod Folder Name"
-                                        IsReadOnly="True"
-                                        Tag="Folder Name" />
-
-                                    <controls:DataGridTextColumn
-                                        Width="SizeToCells"
-                                        Binding="{Binding Author, Mode=OneWay}"
-                                        CanUserSort="True"
-                                        Header="Author"
-                                        IsReadOnly="True"
-                                        Tag="Author Name" />
-
-                                    <controls:DataGridTemplateColumn
-                                        Width="SizeToCells"
-                                        CanUserSort="True"
-                                        Header="Date Added"
-                                        IsReadOnly="True"
-                                        Tag="Date Added">
-                                        <controls:DataGridTemplateColumn.CellTemplate>
-                                            <DataTemplate x:DataType="models:ModModel">
-                                                <Grid
-                                                    Margin="8,0"
-                                                    HorizontalAlignment="Center"
-                                                    VerticalAlignment="Center">
-                                                    <TextBlock
-                                                        HorizontalAlignment="Stretch"
-                                                        VerticalAlignment="Center"
-                                                        Text="{x:Bind DateAdded, Mode=OneWay}" />
-                                                </Grid>
-                                            </DataTemplate>
-                                        </controls:DataGridTemplateColumn.CellTemplate>
-                                    </controls:DataGridTemplateColumn>
-                                </controls:DataGrid.Columns>
-
-                            </controls:DataGrid>
-                        </Grid>
-
-                        <Grid
-                            x:Name="ModDetailsPane"
+                        <StackPanel
                             Grid.Column="1"
-                            Margin="0,0,0,8"
-                            Padding="5,5,5,5"
-                            Background="{ThemeResource ControlFillColorDefaultBrush}"
-                            CornerRadius="10">
-                            <Grid.RowDefinitions>
-                                <RowDefinition Height="Auto" />
-                                <RowDefinition Height="3*" />
-                                <RowDefinition Height="Auto" />
-                                <RowDefinition Height="Auto" />
-                                <RowDefinition Height="Auto" />
-                                <RowDefinition Height="*" />
-                                <RowDefinition Height="Auto" />
-                            </Grid.RowDefinitions>
-                            <Grid Margin="0,0,0,8" VerticalAlignment="Top">
-                                <Button
-                                    HorizontalAlignment="Right"
-                                    Content="Open In New Window"
-                                    IsEnabled="{x:Bind ViewModel.ModPaneVM.IsReadOnlyMode, Mode=OneWay, Converter={StaticResource BoolInverter}}"
-                                    ToolTipService.ToolTip="Set Mod preview image"
-                                    Visibility="Collapsed" />
+                            HorizontalAlignment="Right"
+                            VerticalAlignment="Center"
+                            Orientation="Horizontal"
+                            Spacing="16">
+
+                            <InfoBar
+                                Height="50"
+                                VerticalAlignment="Center"
+                                IsClosable="False"
+                                IsOpen="{x:Bind ViewModel.ModListVM.IsInfoBarOpen, Mode=OneWay}"
+                                Message="{x:Bind ViewModel.ModListVM.InfoBarMessage, Mode=OneWay}"
+                                Severity="{x:Bind ViewModel.ModListVM.Severity, Mode=OneWay}"
+                                Visibility="Visible" />
+
+                            <ToggleSwitch
+                                x:Name="ViewToggleSwitch"
+                                IsOn="False"
+                                OffContent="Detailed View"
+                                OnContent="Gallery View"
+                                Toggled="ViewToggleSwitch_OnToggled" />
+
+                            <Grid MinWidth="32">
+                                <ProgressRing IsActive="{x:Bind ViewModel.IsAddingModFolder, Mode=OneWay}" />
                             </Grid>
+
+                        </StackPanel>
+
+                    </Grid>
+                    <Grid
+                        x:Name="MainContentArea"
+                        Grid.Row="1"
+                        AllowDrop="False"
+                        Background="Transparent"
+                        DragOver="ModListArea_OnDragOver"
+                        Drop="ModListArea_OnDrop">
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="7*" />
+                                <ColumnDefinition Width="3*" />
+                            </Grid.ColumnDefinitions>
                             <Grid
-                                Grid.Row="1"
-                                MinWidth="200"
-                                MinHeight="200"
+                                x:Name="ModListArea"
                                 AllowDrop="True"
-                                Background="{ThemeResource ControlFillColorTertiaryBrush}"
-                                ContextFlyout="{Binding ElementName=ImageFlyout}"
+                                Background="Transparent"
                                 CornerRadius="10"
-                                DragEnter="ModDetailsPaneImage_OnDragEnter"
-                                DragOver="ModDetailsPaneImage_OnDragOver"
-                                Drop="ModDetailsPaneImage_OnDrop">
-                                <Image ImageFailed="Image_OnImageFailed" Stretch="Uniform">
-                                    <Image.Source>
-                                        <BitmapImage CreateOptions="IgnoreImageCache" UriSource="{x:Bind ViewModel.ModPaneVM.SelectedModModel.ImagePath, Mode=OneWay}" />
-                                    </Image.Source>
-                                </Image>
-                                <Button
-                                    Margin="0,20,20,0"
-                                    HorizontalAlignment="Right"
-                                    VerticalAlignment="Top"
-                                    Command="{x:Bind ViewModel.ModPaneVM.SetImageUriCommand}"
-                                    IsEnabled="{x:Bind ViewModel.ModPaneVM.IsReadOnlyMode, Mode=OneWay, Converter={StaticResource BoolInverter}}">
-                                    <FontIcon Glyph="&#xE70F;" />
-                                </Button>
+                                DragOver="ModListArea_OnDragOver"
+                                Drop="ModListArea_OnDrop">
+                                <controls:DataGrid
+                                    x:Name="ModListGrid"
+                                    AllowDrop="False"
+                                    AutoGenerateColumns="False"
+                                    CanUserReorderColumns="False"
+                                    CanUserResizeColumns="True"
+                                    CellEditEnded="ModListGrid_OnCellEditEnded"
+                                    ContextFlyout="{Binding ElementName=ModRowFlyout}"
+                                    FrozenColumnCount="3"
+                                    GridLinesVisibility="All"
+                                    ItemsSource="{x:Bind ViewModel.ModListVM.Mods, Mode=OneWay}"
+                                    KeyDown="ModListGrid_OnKeyDown"
+                                    SelectionChanged="ModListGrid_OnSelectionChanged"
+                                    SelectionMode="Extended"
+                                    Sorting="ModListGrid_OnSorting">
+                                    <controls:DataGrid.Columns>
+                                        <controls:DataGridTemplateColumn
+                                            Width="SizeToHeader"
+                                            CanUserResize="False"
+                                            CanUserSort="True"
+                                            Header="Enabled"
+                                            Tag="IsEnabled">
+
+                                            <controls:DataGridTemplateColumn.CellTemplate>
+                                                <DataTemplate x:DataType="models:ModModel">
+                                                    <Grid HorizontalAlignment="Center" VerticalAlignment="Center">
+                                                        <CheckBox
+                                                            Width="Auto"
+                                                            MinWidth="0"
+                                                            Command="{x:Bind ToggleModCommand}"
+                                                            IsChecked="{x:Bind IsEnabled, Mode=OneWay}"
+                                                            IsTabStop="False" />
+                                                    </Grid>
+                                                </DataTemplate>
+                                            </controls:DataGridTemplateColumn.CellTemplate>
+                                        </controls:DataGridTemplateColumn>
+
+
+                                        <controls:DataGridTemplateColumn
+                                            Width="SizeToCells"
+                                            MinWidth="0"
+                                            CanUserSort="False"
+                                            Header=""
+                                            IsReadOnly="True"
+                                            Tag="NotificationColumn">
+                                            <controls:DataGridTemplateColumn.CellTemplate>
+                                                <DataTemplate x:DataType="models:ModModel">
+
+                                                    <StackPanel
+                                                        HorizontalAlignment="Center"
+                                                        VerticalAlignment="Center"
+                                                        Orientation="Horizontal">
+                                                        <ItemsRepeater ItemsSource="{x:Bind ModNotifications, Mode=OneWay}">
+                                                            <ItemsRepeater.ItemTemplate>
+                                                                <DataTemplate x:DataType="notifications:ModNotification">
+                                                                    <Grid Margin="4,0" VerticalAlignment="Center">
+                                                                        <Button
+                                                                            Margin="0"
+                                                                            Padding="0"
+                                                                            BorderThickness="0"
+                                                                            Click="ButtonBase_OnClick"
+                                                                            CornerRadius="0"
+                                                                            DataContext="{x:Bind}"
+                                                                            PointerEntered="NotificationButton_OnPointerEntered"
+                                                                            PointerExited="NotificationButton_OnPointerExited">
+                                                                            <Button.Content>
+                                                                                <FontIcon
+                                                                                    VerticalAlignment="Bottom"
+                                                                                    Foreground="{ThemeResource AccentTextFillColorTertiaryBrush}"
+                                                                                    Glyph="{x:Bind AttentionType, Converter={StaticResource AttentionTypeToSymbolConverter}}" />
+                                                                            </Button.Content>
+                                                                        </Button>
+                                                                    </Grid>
+                                                                </DataTemplate>
+                                                            </ItemsRepeater.ItemTemplate>
+                                                        </ItemsRepeater>
+                                                    </StackPanel>
+
+                                                </DataTemplate>
+                                            </controls:DataGridTemplateColumn.CellTemplate>
+                                        </controls:DataGridTemplateColumn>
+
+                                        <controls:DataGridTemplateColumn
+                                            Width="SizeToCells"
+                                            CanUserSort="True"
+                                            Header="Mod Name"
+                                            IsReadOnly="True"
+                                            Tag="Name">
+                                            <controls:DataGridTemplateColumn.CellTemplate>
+                                                <DataTemplate x:DataType="models:ModModel">
+                                                    <Grid Margin="8,0">
+                                                        <TextBlock
+                                                            HorizontalAlignment="Stretch"
+                                                            VerticalAlignment="Center"
+                                                            DoubleTapped="ModNameCell_OnDoubleTapped"
+                                                            Text="{x:Bind Name, Mode=OneWay}" />
+                                                    </Grid>
+                                                </DataTemplate>
+                                            </controls:DataGridTemplateColumn.CellTemplate>
+                                        </controls:DataGridTemplateColumn>
+                                        <controls:DataGridTextColumn
+                                            Width="SizeToCells"
+                                            Binding="{Binding FolderName, Mode=OneWay}"
+                                            CanUserSort="True"
+                                            Header="Mod Folder Name"
+                                            IsReadOnly="True"
+                                            Tag="Folder Name" />
+
+                                        <controls:DataGridTextColumn
+                                            Width="SizeToCells"
+                                            Binding="{Binding Author, Mode=OneWay}"
+                                            CanUserSort="True"
+                                            Header="Author"
+                                            IsReadOnly="True"
+                                            Tag="Author Name" />
+
+                                        <controls:DataGridTemplateColumn
+                                            Width="SizeToCells"
+                                            CanUserSort="True"
+                                            Header="Date Added"
+                                            IsReadOnly="True"
+                                            Tag="Date Added">
+                                            <controls:DataGridTemplateColumn.CellTemplate>
+                                                <DataTemplate x:DataType="models:ModModel">
+                                                    <Grid
+                                                        Margin="8,0"
+                                                        HorizontalAlignment="Center"
+                                                        VerticalAlignment="Center">
+                                                        <TextBlock
+                                                            HorizontalAlignment="Stretch"
+                                                            VerticalAlignment="Center"
+                                                            Text="{x:Bind DateAdded, Mode=OneWay}" />
+                                                    </Grid>
+                                                </DataTemplate>
+                                            </controls:DataGridTemplateColumn.CellTemplate>
+                                        </controls:DataGridTemplateColumn>
+                                    </controls:DataGrid.Columns>
+
+                                </controls:DataGrid>
                             </Grid>
-                            <Grid Grid.Row="2">
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="*" />
-                                    <ColumnDefinition Width="Auto" />
-                                </Grid.ColumnDefinitions>
-                                <controls1:EditableTextBlock
-                                    x:Name="ModNameTextBlock"
-                                    Margin="0,8"
-                                    HorizontalAlignment="Stretch"
-                                    IsEditMode="{x:Bind ViewModel.ModPaneVM.IsEditingModName, Mode=OneWay}"
-                                    Style="{ThemeResource SubtitleTextBlockStyle}"
-                                    TextAlignment="Center"
-                                    ToolTipService.ToolTip="Change mod display name"
-                                    Text="{x:Bind ViewModel.ModPaneVM.SelectedModModel.Name, Mode=TwoWay}" />
 
-                                <SplitButton
-                                    Grid.Column="1"
-                                    Command="{x:Bind ViewModel.ModPaneVM.ToggleEditingModNameCommand}"
-                                    IsEnabled="{x:Bind ViewModel.ModPaneVM.IsReadOnlyMode, Mode=OneWay, Converter={StaticResource BoolInverter}}">
-                                    <FontIcon Glyph="&#xE70F;" />
-                                    <SplitButton.Flyout>
-                                        <MenuFlyout Placement="Bottom">
-                                            <MenuFlyoutItem
-                                                Command="{x:Bind ViewModel.ModPaneVM.SetModIniFileCommand}"
-                                                ToolTipService.ToolTip="Set the mod .ini file to be read by JASM"
-                                                Text="Set mod .ini file" />
-                                            <MenuFlyoutItem
-                                                Command="{x:Bind ViewModel.ModPaneVM.ClearSetModIniFileCommand}"
-                                                Icon="Clear"
-                                                ToolTipService.ToolTip="JASM will not look for merged.ini/Script.ini file and ignore keyswaps for this mod"
-                                                Text="Ignore .ini file for this mod" />
-                                        </MenuFlyout>
-                                    </SplitButton.Flyout>
-
-                                </SplitButton>
-                            </Grid>
-
-                            <Grid Grid.Row="3">
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="*" />
-                                    <ColumnDefinition Width="Auto" />
-                                </Grid.ColumnDefinitions>
-                                <TextBox
-                                    VerticalAlignment="Center"
-                                    Header="Mod Url:"
-                                    IsEnabled="{x:Bind ViewModel.ModPaneVM.IsReadOnlyMode, Mode=OneWay, Converter={StaticResource BoolInverter}}"
-                                    Text="{x:Bind ViewModel.ModPaneVM.SelectedModModel.ModUrl, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-
-                                <HyperlinkButton
-                                    Grid.Column="1"
-                                    VerticalAlignment="Bottom"
-                                    IsEnabled="{x:Bind ViewModel.ModPaneVM.IsReadOnlyMode, Mode=OneWay, Converter={StaticResource BoolInverter}}"
-                                    NavigateUri="{x:Bind ViewModel.ModPaneVM.SelectedModModel.ModUrl, Mode=OneWay, Converter={StaticResource StringToUri}}">
-                                    <FontIcon FontSize="18" Glyph="&#xE8A7;" />
-                                </HyperlinkButton>
-
-                            </Grid>
-
-
-                            <StackPanel Grid.Row="4" Orientation="Horizontal">
-                                <TextBlock Visibility="Collapsed" Text="Latest Version:" />
-                                <TextBlock Text="{x:Bind ViewModel.ModPaneVM.SelectedModModel.ModUrl}" />
-
-                            </StackPanel>
-
-                            <ScrollViewer
-                                Grid.Row="5"
-                                Margin="0,12,0,0"
-                                Padding="0,0,14,0"
-                                VerticalScrollBarVisibility="Auto">
-
-                                <controls:SwitchPresenter Value="{x:Bind ViewModel.ModPaneVM.ShowKeySwapSection, Mode=OneWay}">
-                                    <controls:Case Value="true">
-                                        <StackPanel>
-                                            <ItemsRepeater ItemsSource="{x:Bind ViewModel.ModPaneVM.SelectedModModel.SkinModKeySwaps, Mode=OneWay}">
-                                                <ItemsRepeater.ItemTemplate>
-                                                    <DataTemplate x:DataType="models:SkinModKeySwapModel">
-                                                        <Grid Margin="0,0">
-                                                            <Grid.ColumnDefinitions>
-                                                                <ColumnDefinition Width="*" />
-                                                                <ColumnDefinition Width="*" />
-                                                                <ColumnDefinition Width="*" />
-                                                            </Grid.ColumnDefinitions>
-                                                            <TextBox
-                                                                MinWidth="100"
-                                                                HorizontalAlignment="Left"
-                                                                Header="Forward Key"
-                                                                Text="{x:Bind ForwardHotkey, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-
-                                                            <StackPanel Grid.Column="1" VerticalAlignment="Center">
-                                                                <TextBlock HorizontalAlignment="Center" Text="{x:Bind SectionKey}" />
-                                                                <StackPanel HorizontalAlignment="Center" Orientation="Horizontal">
-                                                                    <TextBlock Margin="0,0,4,0" Text="Variations: " />
-                                                                    <TextBlock Text="{x:Bind VariationsCount, Mode=OneWay}" />
-                                                                </StackPanel>
-                                                            </StackPanel>
-                                                            <TextBox
-                                                                Grid.Column="2"
-                                                                MinWidth="100"
-                                                                HorizontalAlignment="Right"
-                                                                Header="Backward Key"
-                                                                Text="{x:Bind BackwardHotkey, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-                                                        </Grid>
-                                                    </DataTemplate>
-                                                </ItemsRepeater.ItemTemplate>
-                                            </ItemsRepeater>
-
-                                        </StackPanel>
-                                    </controls:Case>
-
-                                    <controls:Case Value="false">
-                                        <TextBlock
-                                            HorizontalAlignment="Center"
-                                            VerticalAlignment="Top"
-                                            TextWrapping="WrapWholeWords"
-                                            Text="Key swap management is disabled for this mod" />
-
-                                    </controls:Case>
-                                </controls:SwitchPresenter>
-
-
-
-                            </ScrollViewer>
-                            <Grid Grid.Row="6" Padding="0,12">
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="Auto" />
-                                    <ColumnDefinition />
-                                    <ColumnDefinition Width="Auto" />
-                                </Grid.ColumnDefinitions>
-                                <Button
-                                    Background="{ThemeResource SystemFillColorAttentionBrush}"
-                                    Command="{x:Bind ViewModel.ModPaneVM.SaveModSettingsCommand}"
-                                    IsEnabled="{x:Bind ViewModel.ModPaneVM.IsReadOnlyMode, Mode=OneWay, Converter={StaticResource BoolInverter}}">
-                                    <Button.Content>
-                                        <StackPanel Orientation="Horizontal">
-                                            <FontIcon Margin="0,0,4,0" Glyph="&#xE74E;" />
-                                            <TextBlock Text="Save" />
-                                        </StackPanel>
-                                    </Button.Content>
-                                    <Button.KeyboardAccelerators>
-                                        <KeyboardAccelerator Key="S" Modifiers="Control" />
-                                    </Button.KeyboardAccelerators>
-
-                                </Button>
-
-                                <Grid Grid.Column="1" Visibility="{x:Bind ViewModel.ModPaneVM.SelectedModModel.IsEnabled, Mode=OneWay}">
-
+                            <Grid
+                                x:Name="ModDetailsPane"
+                                Grid.Column="1"
+                                Margin="0,0,0,8"
+                                Padding="5,5,5,5"
+                                Background="{ThemeResource ControlFillColorDefaultBrush}"
+                                CornerRadius="10">
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto" />
+                                    <RowDefinition Height="3*" />
+                                    <RowDefinition Height="Auto" />
+                                    <RowDefinition Height="Auto" />
+                                    <RowDefinition Height="Auto" />
+                                    <RowDefinition Height="*" />
+                                    <RowDefinition Height="Auto" />
+                                </Grid.RowDefinitions>
+                                <Grid Margin="0,0,0,8" VerticalAlignment="Top">
+                                    <Button
+                                        HorizontalAlignment="Right"
+                                        Content="Open In New Window"
+                                        IsEnabled="{x:Bind ViewModel.ModPaneVM.IsReadOnlyMode, Mode=OneWay, Converter={StaticResource BoolInverter}}"
+                                        ToolTipService.ToolTip="Set Mod preview image"
+                                        Visibility="Collapsed" />
+                                </Grid>
+                                <Grid
+                                    Grid.Row="1"
+                                    MinWidth="200"
+                                    MinHeight="200"
+                                    AllowDrop="True"
+                                    Background="{ThemeResource ControlFillColorTertiaryBrush}"
+                                    ContextFlyout="{Binding ElementName=ImageFlyout}"
+                                    CornerRadius="10"
+                                    DragEnter="ModDetailsPaneImage_OnDragEnter"
+                                    DragOver="ModDetailsPaneImage_OnDragOver"
+                                    Drop="ModDetailsPaneImage_OnDrop">
+                                    <Image ImageFailed="Image_OnImageFailed" Stretch="Uniform">
+                                        <Image.Source>
+                                            <BitmapImage CreateOptions="IgnoreImageCache" UriSource="{x:Bind ViewModel.ModPaneVM.SelectedModModel.ImagePath, Mode=OneWay}" />
+                                        </Image.Source>
+                                    </Image>
+                                    <Button
+                                        Margin="0,20,20,0"
+                                        HorizontalAlignment="Right"
+                                        VerticalAlignment="Top"
+                                        Command="{x:Bind ViewModel.ModPaneVM.SetImageUriCommand}"
+                                        IsEnabled="{x:Bind ViewModel.ModPaneVM.IsReadOnlyMode, Mode=OneWay, Converter={StaticResource BoolInverter}}">
+                                        <FontIcon Glyph="&#xE70F;" />
+                                    </Button>
+                                </Grid>
+                                <Grid Grid.Row="2">
                                     <Grid.ColumnDefinitions>
                                         <ColumnDefinition Width="*" />
                                         <ColumnDefinition Width="Auto" />
-                                        <ColumnDefinition Width="*" />
                                     </Grid.ColumnDefinitions>
+                                    <controls1:EditableTextBlock
+                                        x:Name="ModNameTextBlock"
+                                        Margin="0,8"
+                                        HorizontalAlignment="Stretch"
+                                        IsEditMode="{x:Bind ViewModel.ModPaneVM.IsEditingModName, Mode=OneWay}"
+                                        Style="{ThemeResource SubtitleTextBlockStyle}"
+                                        TextAlignment="Center"
+                                        ToolTipService.ToolTip="Change mod display name"
+                                        Text="{x:Bind ViewModel.ModPaneVM.SelectedModModel.Name, Mode=TwoWay}" />
 
-                                    <Border
+                                    <SplitButton
                                         Grid.Column="1"
-                                        Background="{ThemeResource AccentFillColorSelectedTextBackgroundBrush}"
-                                        CornerRadius="10">
-                                        <TextBlock
-                                            Padding="4,0"
-                                            HorizontalAlignment="Center"
-                                            VerticalAlignment="Center"
-                                            Text="Mod Enabled" />
-                                    </Border>
+                                        Command="{x:Bind ViewModel.ModPaneVM.ToggleEditingModNameCommand}"
+                                        IsEnabled="{x:Bind ViewModel.ModPaneVM.IsReadOnlyMode, Mode=OneWay, Converter={StaticResource BoolInverter}}">
+                                        <FontIcon Glyph="&#xE70F;" />
+                                        <SplitButton.Flyout>
+                                            <MenuFlyout Placement="Bottom">
+                                                <MenuFlyoutItem
+                                                    Command="{x:Bind ViewModel.ModPaneVM.SetModIniFileCommand}"
+                                                    ToolTipService.ToolTip="Set the mod .ini file to be read by JASM"
+                                                    Text="Set mod .ini file" />
+                                                <MenuFlyoutItem
+                                                    Command="{x:Bind ViewModel.ModPaneVM.ClearSetModIniFileCommand}"
+                                                    Icon="Clear"
+                                                    ToolTipService.ToolTip="JASM will not look for merged.ini/Script.ini file and ignore keyswaps for this mod"
+                                                    Text="Ignore .ini file for this mod" />
+                                            </MenuFlyout>
+                                        </SplitButton.Flyout>
+
+                                    </SplitButton>
+                                </Grid>
+
+                                <Grid Grid.Row="3">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="*" />
+                                        <ColumnDefinition Width="Auto" />
+                                    </Grid.ColumnDefinitions>
+                                    <TextBox
+                                        VerticalAlignment="Center"
+                                        Header="Mod Url:"
+                                        IsEnabled="{x:Bind ViewModel.ModPaneVM.IsReadOnlyMode, Mode=OneWay, Converter={StaticResource BoolInverter}}"
+                                        Text="{x:Bind ViewModel.ModPaneVM.SelectedModModel.ModUrl, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+
+                                    <HyperlinkButton
+                                        Grid.Column="1"
+                                        VerticalAlignment="Bottom"
+                                        IsEnabled="{x:Bind ViewModel.ModPaneVM.IsReadOnlyMode, Mode=OneWay, Converter={StaticResource BoolInverter}}"
+                                        NavigateUri="{x:Bind ViewModel.ModPaneVM.SelectedModModel.ModUrl, Mode=OneWay, Converter={StaticResource StringToUri}}">
+                                        <FontIcon FontSize="18" Glyph="&#xE8A7;" />
+                                    </HyperlinkButton>
 
                                 </Grid>
 
 
-                                <Button
-                                    Grid.Column="2"
-                                    HorizontalAlignment="Right"
-                                    Command="{x:Bind ViewModel.ModPaneVM.OpenModFolderCommand}"
-                                    Content="Open Mod Folder..."
-                                    IsEnabled="{x:Bind ViewModel.ModPaneVM.IsReadOnlyMode, Mode=OneWay, Converter={StaticResource BoolInverter}}" />
+                                <StackPanel Grid.Row="4" Orientation="Horizontal">
+                                    <TextBlock Visibility="Collapsed" Text="Latest Version:" />
+                                    <TextBlock Text="{x:Bind ViewModel.ModPaneVM.SelectedModModel.ModUrl}" />
+
+                                </StackPanel>
+
+                                <ScrollViewer
+                                    Grid.Row="5"
+                                    Margin="0,12,0,0"
+                                    Padding="0,0,14,0"
+                                    VerticalScrollBarVisibility="Auto">
+
+                                    <controls:SwitchPresenter Value="{x:Bind ViewModel.ModPaneVM.ShowKeySwapSection, Mode=OneWay}">
+                                        <controls:Case Value="true">
+                                            <StackPanel>
+                                                <ItemsRepeater ItemsSource="{x:Bind ViewModel.ModPaneVM.SelectedModModel.SkinModKeySwaps, Mode=OneWay}">
+                                                    <ItemsRepeater.ItemTemplate>
+                                                        <DataTemplate x:DataType="models:SkinModKeySwapModel">
+                                                            <Grid Margin="0,0">
+                                                                <Grid.ColumnDefinitions>
+                                                                    <ColumnDefinition Width="*" />
+                                                                    <ColumnDefinition Width="*" />
+                                                                    <ColumnDefinition Width="*" />
+                                                                </Grid.ColumnDefinitions>
+                                                                <TextBox
+                                                                    MinWidth="100"
+                                                                    HorizontalAlignment="Left"
+                                                                    Header="Forward Key"
+                                                                    Text="{x:Bind ForwardHotkey, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+
+                                                                <StackPanel Grid.Column="1" VerticalAlignment="Center">
+                                                                    <TextBlock HorizontalAlignment="Center" Text="{x:Bind SectionKey}" />
+                                                                    <StackPanel HorizontalAlignment="Center" Orientation="Horizontal">
+                                                                        <TextBlock Margin="0,0,4,0" Text="Variations: " />
+                                                                        <TextBlock Text="{x:Bind VariationsCount, Mode=OneWay}" />
+                                                                    </StackPanel>
+                                                                </StackPanel>
+                                                                <TextBox
+                                                                    Grid.Column="2"
+                                                                    MinWidth="100"
+                                                                    HorizontalAlignment="Right"
+                                                                    Header="Backward Key"
+                                                                    Text="{x:Bind BackwardHotkey, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                                                            </Grid>
+                                                        </DataTemplate>
+                                                    </ItemsRepeater.ItemTemplate>
+                                                </ItemsRepeater>
+
+                                            </StackPanel>
+                                        </controls:Case>
+
+                                        <controls:Case Value="false">
+                                            <TextBlock
+                                                HorizontalAlignment="Center"
+                                                VerticalAlignment="Top"
+                                                TextWrapping="WrapWholeWords"
+                                                Text="Key swap management is disabled for this mod" />
+
+                                        </controls:Case>
+                                    </controls:SwitchPresenter>
+
+
+
+                                </ScrollViewer>
+                                <Grid Grid.Row="6" Padding="0,12">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto" />
+                                        <ColumnDefinition />
+                                        <ColumnDefinition Width="Auto" />
+                                    </Grid.ColumnDefinitions>
+                                    <Button
+                                        Background="{ThemeResource SystemFillColorAttentionBrush}"
+                                        Command="{x:Bind ViewModel.ModPaneVM.SaveModSettingsCommand}"
+                                        IsEnabled="{x:Bind ViewModel.ModPaneVM.IsReadOnlyMode, Mode=OneWay, Converter={StaticResource BoolInverter}}">
+                                        <Button.Content>
+                                            <StackPanel Orientation="Horizontal">
+                                                <FontIcon Margin="0,0,4,0" Glyph="&#xE74E;" />
+                                                <TextBlock Text="Save" />
+                                            </StackPanel>
+                                        </Button.Content>
+                                        <Button.KeyboardAccelerators>
+                                            <KeyboardAccelerator Key="S" Modifiers="Control" />
+                                        </Button.KeyboardAccelerators>
+
+                                    </Button>
+
+                                    <Grid Grid.Column="1" Visibility="{x:Bind ViewModel.ModPaneVM.SelectedModModel.IsEnabled, Mode=OneWay}">
+
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="*" />
+                                            <ColumnDefinition Width="Auto" />
+                                            <ColumnDefinition Width="*" />
+                                        </Grid.ColumnDefinitions>
+
+                                        <Border
+                                            Grid.Column="1"
+                                            Background="{ThemeResource AccentFillColorSelectedTextBackgroundBrush}"
+                                            CornerRadius="10">
+                                            <TextBlock
+                                                Padding="4,0"
+                                                HorizontalAlignment="Center"
+                                                VerticalAlignment="Center"
+                                                Text="Mod Enabled" />
+                                        </Border>
+
+                                    </Grid>
+
+
+                                    <Button
+                                        Grid.Column="2"
+                                        HorizontalAlignment="Right"
+                                        Command="{x:Bind ViewModel.ModPaneVM.OpenModFolderCommand}"
+                                        Content="Open Mod Folder..."
+                                        IsEnabled="{x:Bind ViewModel.ModPaneVM.IsReadOnlyMode, Mode=OneWay, Converter={StaticResource BoolInverter}}" />
+                                </Grid>
                             </Grid>
+                            <controls:GridSplitter
+                                x:Name="ModPaneSplitter"
+                                Grid.Column="1"
+                                Width="8"
+                                Height="40"
+                                HorizontalAlignment="Left"
+                                ResizeBehavior="BasedOnAlignment"
+                                ResizeDirection="Auto">
+                                <controls:GridSplitter.RenderTransform>
+                                    <TranslateTransform X="-10" />
+                                </controls:GridSplitter.RenderTransform>
+                            </controls:GridSplitter>
                         </Grid>
-                        <controls:GridSplitter
-                            x:Name="ModPaneSplitter"
-                            Grid.Column="1"
-                            Width="8"
-                            Height="40"
-                            HorizontalAlignment="Left"
-                            ResizeBehavior="BasedOnAlignment"
-                            ResizeDirection="Auto">
-                            <controls:GridSplitter.RenderTransform>
-                                <TranslateTransform X="-10" />
-                            </controls:GridSplitter.RenderTransform>
-                        </controls:GridSplitter>
                     </Grid>
+
+
                 </Grid>
-
-
             </Grid>
 
         </Grid>

--- a/src/GIMI-ModManager.WinUI/Views/CharacterDetailsPage.xaml.cs
+++ b/src/GIMI-ModManager.WinUI/Views/CharacterDetailsPage.xaml.cs
@@ -26,6 +26,8 @@ public sealed partial class CharacterDetailsPage : Page
 {
     public CharacterDetailsViewModel ViewModel { get; }
 
+    public Visibility PageLoader = Visibility.Visible;
+
     private readonly MenuFlyout _modListContextMenuFlyout = new();
 
     private static (string, ModListVM.SortMethod)? _currentSortMethod;
@@ -61,7 +63,7 @@ public sealed partial class CharacterDetailsPage : Page
             }
             finally
             {
-                ViewModel.IsFullPageLoaderVisible = false;
+                PageLoader = Visibility.Collapsed;
             }
 
             if (_currentSortMethod is null) return;
@@ -125,7 +127,6 @@ public sealed partial class CharacterDetailsPage : Page
     {
         if (ViewModel.ModListVM.BackendMods.Any())
         {
-            ViewModel.IsFullPageLoaderVisible = true;
             var stackPanel = MainContentArea.FindName("NoModsStackPanel") as StackPanel;
             if (stackPanel != null) stackPanel.Visibility = Visibility.Collapsed;
 
@@ -137,7 +138,6 @@ public sealed partial class CharacterDetailsPage : Page
         }
         else if (MainContentArea.FindName("NoModsStackPanel") is null)
         {
-            ViewModel.IsFullPageLoaderVisible = false;
             ModListGrid.Visibility = Visibility.Collapsed;
             ModDetailsPane.Visibility = Visibility.Collapsed;
             ModPaneSplitter.Visibility = Visibility.Collapsed;
@@ -205,10 +205,6 @@ public sealed partial class CharacterDetailsPage : Page
             dottedLineBox.Child = dropText;
 
             MainContentArea.Children.Add(stackPanel);
-        }
-        else
-        {
-            ViewModel.IsFullPageLoaderVisible = false;
         }
     }
 

--- a/src/GIMI-ModManager.WinUI/Views/CharacterDetailsPage.xaml.cs
+++ b/src/GIMI-ModManager.WinUI/Views/CharacterDetailsPage.xaml.cs
@@ -26,8 +26,6 @@ public sealed partial class CharacterDetailsPage : Page
 {
     public CharacterDetailsViewModel ViewModel { get; }
 
-    public Visibility PageLoader = Visibility.Visible;
-
     private readonly MenuFlyout _modListContextMenuFlyout = new();
 
     private static (string, ModListVM.SortMethod)? _currentSortMethod;
@@ -63,7 +61,7 @@ public sealed partial class CharacterDetailsPage : Page
             }
             finally
             {
-                PageLoader = Visibility.Collapsed;
+                ViewModel.IsFullPageLoaderVisible = false;
             }
 
             if (_currentSortMethod is null) return;
@@ -127,6 +125,7 @@ public sealed partial class CharacterDetailsPage : Page
     {
         if (ViewModel.ModListVM.BackendMods.Any())
         {
+            ViewModel.IsFullPageLoaderVisible = true;
             var stackPanel = MainContentArea.FindName("NoModsStackPanel") as StackPanel;
             if (stackPanel != null) stackPanel.Visibility = Visibility.Collapsed;
 
@@ -138,6 +137,7 @@ public sealed partial class CharacterDetailsPage : Page
         }
         else if (MainContentArea.FindName("NoModsStackPanel") is null)
         {
+            ViewModel.IsFullPageLoaderVisible = false;
             ModListGrid.Visibility = Visibility.Collapsed;
             ModDetailsPane.Visibility = Visibility.Collapsed;
             ModPaneSplitter.Visibility = Visibility.Collapsed;
@@ -205,6 +205,10 @@ public sealed partial class CharacterDetailsPage : Page
             dottedLineBox.Child = dropText;
 
             MainContentArea.Children.Add(stackPanel);
+        }
+        else
+        {
+            ViewModel.IsFullPageLoaderVisible = false;
         }
     }
 

--- a/src/GIMI-ModManager.WinUI/Views/CharactersPage.xaml
+++ b/src/GIMI-ModManager.WinUI/Views/CharactersPage.xaml
@@ -251,10 +251,25 @@
                             </Flyout>
                         </AppBarButton.Flyout>
                     </AppBarButton>
-                    <AppBarButton
-                        Icon="Filter"
-                        IsEnabled="False"
-                        Label="Filters:" />
+                    <AppBarButton Icon="Filter" Label="Filters">
+
+                        <AppBarButton.Flyout>
+                            <Flyout>
+                                <ScrollViewer>
+                                    <StackPanel Spacing="8">
+                                        <ToggleButton
+                                            Command="{x:Bind ViewModel.ShowCharactersWithModsCommand}"
+                                            Content="{x:Bind ViewModel.ModToggleText, Mode=OneWay}"
+                                            IsChecked="{x:Bind ViewModel.ShowOnlyCharactersWithMods, Mode=OneWay}" />
+                                        <ToggleButton
+                                            Command="{x:Bind ViewModel.ShowOnlyCharactersWithModNotificationsCommand}"
+                                            Content="{x:Bind ViewModel.ModNotificationsToggleText, Mode=OneWay}"
+                                            IsChecked="{x:Bind ViewModel.ShowOnlyModsWithNotifications, Mode=OneWay}" />
+                                    </StackPanel>
+                                </ScrollViewer>
+                            </Flyout>
+                        </AppBarButton.Flyout>
+                    </AppBarButton>
                 </CommandBar>
                 <ScrollViewer HorizontalScrollBarVisibility="Auto">
                     <GridView
@@ -309,11 +324,7 @@
                 Grid.Column="3"
                 HorizontalAlignment="Right"
                 Orientation="Horizontal">
-                <ToggleButton
-                    Margin="0,0,8,0"
-                    Command="{x:Bind ViewModel.ShowCharactersWithModsCommand}"
-                    Content="{x:Bind ViewModel.ModToggleText, Mode=OneWay}"
-                    IsChecked="{x:Bind ViewModel.ShowOnlyCharactersWithMods, Mode=OneWay}" />
+
 
                 <AutoSuggestBox
                     x:Name="SearchBox"

--- a/src/GIMI-ModManager.WinUI/Views/CharactersPage.xaml.cs
+++ b/src/GIMI-ModManager.WinUI/Views/CharactersPage.xaml.cs
@@ -1,4 +1,5 @@
 using Windows.ApplicationModel.DataTransfer;
+using Windows.Storage;
 using CommunityToolkit.WinUI;
 using GIMI_ModManager.WinUI.Models;
 using GIMI_ModManager.WinUI.ViewModels;
@@ -92,8 +93,27 @@ public sealed partial class CharactersPage : Page
 
     private async void CharacterThumbnail_OnDrop(object sender, DragEventArgs e)
     {
+
         if (((Grid)sender).DataContext is CharacterGridItemModel characterGridItem)
-            await ViewModel.ModDroppedOnCharacterAsync(characterGridItem, await e.DataView.GetStorageItemsAsync());
+        {
+            var urlFormats = new[] { "Text", "UniformResourceLocatorW", "UniformResourceLocator" };
+            if (urlFormats.All(format => e.DataView.Contains(format)))
+            {
+                try
+                {
+                    var uri = await e.DataView.GetWebLinkAsync();
+                    await ViewModel.ModUrlDroppedOnCharacterAsync(characterGridItem, uri);
+
+                }
+                catch (Exception)
+                {
+                    // ignored
+                }
+            }
+            else
+                await ViewModel.ModDroppedOnCharacterAsync(characterGridItem, await e.DataView.GetStorageItemsAsync());
+
+        }
 
         var gridItem = ((Grid)sender);
         SetGridDropHereVisibility(gridItem, Visibility.Collapsed);

--- a/src/GIMI-ModManager.WinUI/Views/Controls/LinkButton.xaml
+++ b/src/GIMI-ModManager.WinUI/Views/Controls/LinkButton.xaml
@@ -25,7 +25,8 @@
             VerticalAlignment="Center"
             Click="ButtonBase_OnClick"
             ContextFlyout="{StaticResource Flyout}"
-            NavigateUri="{x:Bind Link, Mode=OneWay}">
+            NavigateUri="{x:Bind Link, Mode=OneWay}"
+            ToolTipService.ToolTip="{x:Bind Link, Mode=OneWay}">
             <StackPanel Orientation="Horizontal">
                 <TextBlock
                     Margin="0,0,8,0"

--- a/src/GIMI-ModManager.WinUI/Views/GbModPageWindow.xaml
+++ b/src/GIMI-ModManager.WinUI/Views/GbModPageWindow.xaml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <winUiEx:WindowEx
-    x:Class="GIMI_ModManager.WinUI.Views.ModUpdateAvailableWindow"
+    x:Class="GIMI_ModManager.WinUI.Views.GbModPageWindow"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:controls="using:GIMI_ModManager.WinUI.Views.Controls"
@@ -9,10 +9,10 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:local="using:GIMI_ModManager.WinUI.Views"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:modPageViewModels="using:GIMI_ModManager.WinUI.ViewModels.ModPageViewModels"
     xmlns:services="using:GIMI_ModManager.Core.Services"
     xmlns:viewModels="using:GIMI_ModManager.WinUI.ViewModels"
     xmlns:winUiEx="using:WinUIEx"
-    xmlns:modPageViewModels="using:GIMI_ModManager.WinUI.ViewModels.ModPageViewModels"
     x:Name="RootWindow"
     mc:Ignorable="d">
 
@@ -44,12 +44,12 @@
                         Margin="10"
                         FontSize="20"
                         FontWeight="Bold"
-                        Text="New Downloadable Files Found" />
+                        Text="Download Mods from GameBanana" />
 
                     <controls:LinkButton
-                        Link="{x:Bind ViewModel.ModPath, Mode=OneWay}"
-                        Text="{x:Bind ViewModel.ModPath.LocalPath, Mode=OneWay, FallbackValue=ModPath}"
-                        ToolTipService.ToolTip="Open Mod folder..." />
+                        Link="{x:Bind ViewModel.CharacterModListPath, Mode=OneWay}"
+                        ToolTipService.ToolTip="Open Mod folder..."
+                        Text="{x:Bind ViewModel.CharacterModListPath.LocalPath, Mode=OneWay, FallbackValue=ModPath}" />
                 </StackPanel>
 
                 <controls1:SwitchPresenter Grid.Row="1" Value="{x:Bind ViewModel.Initializing, Mode=OneWay}">
@@ -100,8 +100,8 @@
                                                         Margin="8,0"
                                                         VerticalAlignment="Bottom"
                                                         IsTextSelectionEnabled="True"
-                                                        Text="{x:Bind AgeFormated}"
-                                                        ToolTipService.ToolTip="{x:Bind DateAddedTooltipFormat}" />
+                                                        ToolTipService.ToolTip="{x:Bind DateAddedTooltipFormat}"
+                                                        Text="{x:Bind AgeFormated}" />
                                                 </StackPanel>
 
 
@@ -111,13 +111,6 @@
                                                     Grid.Column="0"
                                                     IsTextSelectionEnabled="True"
                                                     Text="{x:Bind Description}" />
-
-                                                <TextBlock
-                                                    Grid.Row="0"
-                                                    Grid.Column="1"
-                                                    HorizontalAlignment="Right"
-                                                    Text="New since last check"
-                                                    Visibility="{Binding Path=IsNew, Mode=OneTime, Converter={StaticResource BoolToVisibilityConverter}}" />
 
                                                 <StackPanel Grid.Row="1" Grid.Column="1">
                                                     <Grid>
@@ -152,9 +145,6 @@
                                                             IsIndeterminate="{x:Bind IsBusy, Mode=OneWay}"
                                                             Visibility="{Binding Path=IsBusy, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}" />
                                                     </Grid>
-
-
-
                                                 </StackPanel>
                                             </Grid>
                                         </controls:BoolBorder>
@@ -178,21 +168,10 @@
                         Width="200"
                         Height="50"
                         HorizontalAlignment="Left"
-                        Command="{x:Bind ViewModel.IgnoreAndCloseCommand}"
-                        Content="Ignore and Close"
+                        Command="{x:Bind ViewModel.CloseCommand}"
+                        Content="Close"
                         IsEnabled="{x:Bind ViewModel.IsNotBusy, Mode=OneWay}"
-                        ToolTipService.ToolTip="Removes the notification and closes this window" />
-
-                    <StackPanel
-                        Grid.Column="1"
-                        Padding="4"
-                        HorizontalAlignment="Right"
-                        Background="{ThemeResource CardBackgroundFillColorSecondaryBrush}"
-                        CornerRadius="4">
-                        <TextBlock Text="Last Check:" />
-                        <TextBlock Text="{x:Bind ViewModel.LastUpdateCheck, Mode=OneWay}" />
-                    </StackPanel>
-
+                        ToolTipService.ToolTip="Close window" />
                 </Grid>
 
             </Grid>
@@ -216,8 +195,8 @@
                         <controls:LinkButton
                             VerticalAlignment="Center"
                             Link="{x:Bind ViewModel.ModPage, Mode=OneWay}"
-                            Text="{x:Bind ViewModel.ModPage, Mode=OneWay}"
-                            ToolTipService.ToolTip="Open in default browser..." />
+                            ToolTipService.ToolTip="Open in default browser..."
+                            Text="{x:Bind ViewModel.ModPage, Mode=OneWay}" />
                     </StackPanel>
                     <Button
                         Grid.Column="1"

--- a/src/GIMI-ModManager.WinUI/Views/GbModPageWindow.xaml.cs
+++ b/src/GIMI-ModManager.WinUI/Views/GbModPageWindow.xaml.cs
@@ -1,0 +1,108 @@
+// To learn more about WinUI, the WinUI project structure,
+// and more about our project templates, see: http://aka.ms/winui-project-info.
+
+using GIMI_ModManager.Core.GamesService.Interfaces;
+using GIMI_ModManager.WinUI.Contracts.Services;
+using GIMI_ModManager.WinUI.ViewModels.ModPageViewModels;
+using Microsoft.UI.Xaml;
+using Microsoft.Web.WebView2.Core;
+
+namespace GIMI_ModManager.WinUI.Views;
+
+public sealed partial class GbModPageWindow : WindowEx
+{
+    public readonly ModPageVM ViewModel;
+    public readonly IThemeSelectorService ThemeSelectorService = App.GetService<IThemeSelectorService>();
+
+    public bool WebViewIsAvailable = false;
+
+
+    private CancellationTokenSource? _cts;
+
+    public GbModPageWindow(Uri gameBananaUri, IModdableObject moddableObject)
+    {
+        _cts = new CancellationTokenSource();
+
+        ViewModel = new ModPageVM(gameBananaUri, moddableObject, this, _cts.Token);
+        InitializeComponent();
+
+        if (Content is FrameworkElement rootElement)
+        {
+            rootElement.RequestedTheme = ThemeSelectorService.Theme;
+        }
+
+        Closed += (_, _) =>
+        {
+            if (_cts is null) return;
+            var cts = _cts;
+            _cts = null;
+            cts?.Cancel();
+            cts?.Dispose();
+        };
+
+        InitWebView();
+    }
+
+    private void InitWebView()
+    {
+        try
+        {
+            CoreWebView2Environment.GetAvailableBrowserVersionString();
+        }
+        catch (Exception e)
+        {
+            return;
+        }
+
+        WebViewIsAvailable = true;
+        ModPageBrowser.Visibility = Visibility.Visible;
+
+        ModPageBrowser.Loading += async (_, _) =>
+        {
+            await ModPageBrowser.EnsureCoreWebView2Async();
+            ModPageBrowser.CoreWebView2.NavigationCompleted += async (_, _) =>
+            {
+                ModPageLoadingRing.IsActive = false;
+                ViewModel.IsOpenDownloadButtonEnabled = true;
+
+                // This automatically opens the author side pane
+                // However, it covered the update date and was annoying so I disabled it
+                // TODO: Change CSS to make it not cover the update date
+                //if (!_isFirstTimeNavigation) return;
+
+                //_isFirstTimeNavigation = false;
+                //await Task.Delay(1000);
+                //var script = "document.getElementById('HiddenColumnToggleButton').click();";
+                //await ModPageBrowser.CoreWebView2.ExecuteScriptAsync(script);
+            };
+            ModPageBrowser.CoreWebView2.NavigationStarting += (_, _) => ModPageLoadingRing.IsActive = true;
+            var theme = ThemeSelectorService.Theme;
+            var webTheme = CoreWebView2PreferredColorScheme.Auto;
+            switch (theme)
+            {
+                case ElementTheme.Light:
+                    webTheme = CoreWebView2PreferredColorScheme.Light;
+                    break;
+                case ElementTheme.Dark:
+                    webTheme = CoreWebView2PreferredColorScheme.Dark;
+                    break;
+                case ElementTheme.Default:
+                    break;
+            }
+
+            ModPageBrowser.CoreWebView2.Profile.PreferredColorScheme = webTheme;
+        };
+    }
+
+    private async void ButtonBase_OnClick(object sender, RoutedEventArgs e)
+    {
+        if (!WebViewIsAvailable)
+            return;
+        await ModPageBrowser.EnsureCoreWebView2Async();
+
+        if (ModPageBrowser.CoreWebView2.IsDefaultDownloadDialogOpen)
+            ModPageBrowser.CoreWebView2.CloseDefaultDownloadDialog();
+        else
+            ModPageBrowser.CoreWebView2.OpenDefaultDownloadDialog();
+    }
+}

--- a/src/GIMI-ModManager.WinUI/Views/ModInstallerPage.xaml
+++ b/src/GIMI-ModManager.WinUI/Views/ModInstallerPage.xaml
@@ -32,8 +32,8 @@
             <MenuFlyoutItem
                 Command="{x:Bind ViewModel.SetShaderFixesFolderCommand}"
                 CommandParameter="{Binding}"
-                Text="Set ShaderFixes Folder"
-                Visibility="Collapsed" />
+                Visibility="Collapsed"
+                Text="Set ShaderFixes Folder" />
         </MenuFlyout>
 
         <DataTemplate x:Key="RootFolderTemplate" x:DataType="viewModels:RootFolder">
@@ -149,11 +149,21 @@
 
                     </Grid>
 
-                    <CheckBox
-                        Grid.Row="2"
-                        Margin="4"
-                        Content="Overwrite existing mod"
-                        IsChecked="{x:Bind ViewModel.OverwriteExistingMod, Mode=TwoWay}" />
+                    <StackPanel Grid.Row="2">
+                        <CheckBox
+                            Margin="4"
+                            Content="Overwrite existing mod"
+                            IsChecked="{x:Bind ViewModel.OverwriteExistingMod, Mode=TwoWay}" />
+
+                        <CheckBox
+                            Margin="4"
+                            Command="{x:Bind ViewModel.ToggleReplaceDuplicateModInPresetCommand}"
+                            IsChecked="{x:Bind ViewModel.ReplaceDuplicateModInPreset, Mode=OneWay}"
+                            ToolTipService.ToolTip="The duplicate mod will be replaced in presets by the newly installed mod. This is mutually exclusive with the 'replace old mod in presets' checkbox.">
+                            <TextBlock TextWrapping="WrapWholeWords" Text="Replace duplicate mod in presets with new mod" />
+                        </CheckBox>
+                    </StackPanel>
+
                 </Grid>
 
             </ContentDialog.Content>
@@ -310,20 +320,20 @@
                     <TextBlock
                         Padding="8"
                         HorizontalAlignment="Left"
-                        Text="Here you can select the root of the mod folder."
-                        TextWrapping="WrapWholeWords" />
+                        TextWrapping="WrapWholeWords"
+                        Text="Here you can select the root of the mod folder." />
 
                     <TextBlock
                         Padding="8"
                         HorizontalAlignment="Left"
-                        Text="This is usually the folder that contains the 'merged.ini/Script.ini' or '.JASM_ModConfig.json'.&#x0a;JASM will automatically detect the mod folder and the merged.ini file. If you want to manually select the mod folder, you can do so by right clicking the folder in the overview above. "
-                        TextWrapping="WrapWholeWords" />
+                        TextWrapping="WrapWholeWords"
+                        Text="This is usually the folder that contains the 'merged.ini/Script.ini' or '.JASM_ModConfig.json'.&#x0a;JASM will automatically detect the mod folder and the merged.ini file. If you want to manually select the mod folder, you can do so by right clicking the folder in the overview above. " />
 
                     <TextBlock
                         Padding="8"
                         HorizontalAlignment="Left"
-                        Text="You can also manually select image file for the mod preview image. It's usually fine to just press 'Add Mod'"
-                        TextWrapping="WrapWholeWords" />
+                        TextWrapping="WrapWholeWords"
+                        Text="You can also manually select image file for the mod preview image. It's usually fine to just press 'Add Mod'" />
 
 
 
@@ -369,18 +379,28 @@
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition />
                         <ColumnDefinition />
+                        <ColumnDefinition />
                     </Grid.ColumnDefinitions>
 
                     <CheckBox
-                        Margin="8,0"
+                        Margin="4,0"
                         Command="{x:Bind ViewModel.EnableOnlyToggleCommand}"
                         Content="Enable this mod and disable others?"
                         IsChecked="{x:Bind ViewModel.EnableThisMod, Mode=OneWay}"
                         ToolTipService.ToolTip="This will enable this mod and disable all other mods. If a character then it will only disable for that characters skin" />
 
-                    <Button
+
+                    <CheckBox
                         Grid.Column="1"
-                        Margin="8,0"
+                        Command="{x:Bind ViewModel.ToggleReplaceModToUpdateInPresetCommand}"
+                        Content="Replace mod to update with new mod in presets"
+                        IsChecked="{x:Bind ViewModel.ReplaceModToUpdateInPreset, Mode=OneWay}"
+                        ToolTipService.ToolTip="This will replace the old mod with an update with this new installed mod for all presets. This checkbox is separate from the checkbox for when a duplicate mod is detected"
+                        Visibility="{x:Bind ViewModel.IsUpdatingMod, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}" />
+
+                    <Button
+                        Grid.Column="2"
+                        Margin="4,0"
                         HorizontalAlignment="Right"
                         Command="{x:Bind ViewModel.AddModCommand}"
                         Content="Add Mod">

--- a/src/GIMI-ModManager.WinUI/Views/ModInstallerPage.xaml
+++ b/src/GIMI-ModManager.WinUI/Views/ModInstallerPage.xaml
@@ -301,8 +301,8 @@
 
                     <StackPanel Orientation="Horizontal">
                         <FontIcon Margin="4,0" Glyph="{x:Bind ViewModel.SelectedImageIcon}" />
-                        <TextBlock Margin="4,0" Text="PreviewImage:" />
-                        <TextBlock Text="Auto" />
+                        <TextBlock Margin="4,0" Text="Preview Image Source:" />
+                        <TextBlock Text="{x:Bind ViewModel.ImageSource, Mode=OneWay}" />
                     </StackPanel>
                     <StackPanel
                         Margin="0,0,0,8"

--- a/src/GIMI-ModManager.WinUI/Views/PresetDetailsPage.xaml
+++ b/src/GIMI-ModManager.WinUI/Views/PresetDetailsPage.xaml
@@ -34,8 +34,8 @@
             <TextBlock
                 Grid.Column="0"
                 Style="{StaticResource TitleTextBlockStyle}"
-                Text="{x:Bind ViewModel.GetPageTitle, Mode=OneWay}"
-                TextWrapping="NoWrap" />
+                TextWrapping="NoWrap"
+                Text="{x:Bind ViewModel.GetPageTitle, Mode=OneWay}" />
 
             <ProgressRing
                 Grid.Column="1"
@@ -80,7 +80,7 @@
             animations:ItemsReorderAnimation.Duration="00:00:00.4460000"
             DesiredWidth="400"
             FlowDirection="LeftToRight"
-            ItemHeight="220"
+            ItemHeight="250"
             ItemsSource="{x:Bind ViewModel.ModEntries}"
             SelectionMode="None">
 
@@ -151,8 +151,8 @@
                                         <MenuFlyoutItem
                                             Command="{x:Bind ReplaceMissingModCommand}"
                                             CommandParameter="{Binding Mode=OneWay}"
-                                            Text="Find Replacement Mod"
-                                            Visibility="{x:Bind IsMissing, Converter={StaticResource BoolToVisibilityConverter}}">
+                                            Visibility="{x:Bind IsMissing, Converter={StaticResource BoolToVisibilityConverter}}"
+                                            Text="Find Replacement Mod">
                                             <MenuFlyoutItem.Icon>
                                                 <FontIcon Glyph="&#xE8DA;" />
                                             </MenuFlyoutItem.Icon>
@@ -160,9 +160,9 @@
                                         <MenuFlyoutItem
                                             Command="{x:Bind ReadAndSavePreferencesCommand}"
                                             CommandParameter="{Binding Mode=OneWay}"
-                                            Text="Read and Save Preferences"
                                             ToolTipService.ToolTip="Read current 3Dmigoto user ini for his mod and save preference for this preset"
-                                            Visibility="{x:Bind IsNotMissing, Converter={StaticResource BoolToVisibilityConverter}}">
+                                            Visibility="{x:Bind IsNotMissing, Converter={StaticResource BoolToVisibilityConverter}}"
+                                            Text="Read and Save Preferences">
                                             <MenuFlyoutItem.Icon>
                                                 <FontIcon Glyph="&#xE74E;" />
                                             </MenuFlyoutItem.Icon>
@@ -206,14 +206,14 @@
                                 <TextBlock
                                     FontSize="16"
                                     IsTextSelectionEnabled="True"
-                                    Text="{x:Bind Name}"
-                                    TextWrapping="WrapWholeWords" />
+                                    TextWrapping="WrapWholeWords"
+                                    Text="{x:Bind Name}" />
 
                                 <controls1:LinkButton
                                     HorizontalAlignment="Center"
                                     Link="{x:Bind SourceUrl}"
-                                    Text="{x:Bind ModUrlName}"
-                                    Visibility="{x:Bind HasSourceUrl, Converter={StaticResource BoolToVisibilityConverter}}" />
+                                    Visibility="{x:Bind HasSourceUrl, Converter={StaticResource BoolToVisibilityConverter}}"
+                                    Text="{x:Bind ModUrlName}" />
 
                                 <StackPanel>
                                     <TextBlock HorizontalAlignment="Center" Text="Added To Preset At:" />
@@ -236,9 +236,9 @@
                                     <TextBlock
                                         HorizontalAlignment="Center"
                                         IsTextSelectionEnabled="True"
-                                        Text="{x:Bind FullPath}"
                                         TextWrapping="Wrap"
-                                        ToolTipService.ToolTip="{x:Bind FullPath}" />
+                                        ToolTipService.ToolTip="{x:Bind FullPath}"
+                                        Text="{x:Bind FullPath}" />
                                 </StackPanel>
                             </StackPanel>
 

--- a/src/GIMI-ModManager.WinUI/Views/Settings/SettingsPage.xaml
+++ b/src/GIMI-ModManager.WinUI/Views/Settings/SettingsPage.xaml
@@ -420,7 +420,11 @@
                             Margin="8,0"
                             VerticalAlignment="Center"
                             Text="{x:Bind ViewModel.LatestVersion, Mode=OneWay}" />
+
+                        <controls:LinkButton Link="https://github.com/Jorixon/JASM/releases/latest" Text="See what's new in the latest release" />
+
                     </StackPanel>
+
 
                     <StackPanel Margin="0,16,0,16" Orientation="Horizontal">
                         <Button

--- a/src/GIMI-ModManager.WinUI/Views/Settings/SettingsPage.xaml
+++ b/src/GIMI-ModManager.WinUI/Views/Settings/SettingsPage.xaml
@@ -357,6 +357,16 @@
                         </StackPanel>
                     </StackPanel>
 
+
+                    <TextBlock IsTextSelectionEnabled="True">
+                        <Run Text="Current Size of Mod Cache for" />
+                        <Run Text="{x:Bind ViewModel.SelectedGame, Mode=OneWay}" />
+                        <Run Text=":" />
+                        <Run Text="{x:Bind ViewModel.ModCacheSizeGB, Mode=OneWay}" />
+                        <Run Text="GB" />
+
+                    </TextBlock>
+
                 </StackPanel>
 
                 <TextBlock


### PR DESCRIPTION
feat: For the CharacterDetailsPage grid ordering is persisted in memory

feat: Allow for automatically replacing an existing mod in a preset with a new mod when installing new mods.

feat: Now possible to filter to only characters where there is a mod notification i.e. Mod update / new mod added.

feat: Now possible to start JASM and switch to specific game trough command line args. See FAQ for example.

chore: When updating a mod, the existing JASM_ModConfig will take precedence over settings taken from GameBanana

chore: Added link to Github releases on the settings page when a new update is available.

chore: Current size of the local mod cache is now shown on the settings page