### PR TITLE
feat(preset): support randomizing mods at charactors page

### DIFF
--- a/src/GIMI-ModManager.WinUI/App.xaml.cs
+++ b/src/GIMI-ModManager.WinUI/App.xaml.cs
@@ -276,6 +276,8 @@ public partial class App : Application
                 // Configuration
                 services.Configure<LocalSettingsOptions>(
                     context.Configuration.GetSection(nameof(LocalSettingsOptions)));
+
+                services.AddSingleton<ModRandomizationService>();
             }).Build();
 
         UnhandledException += App_UnhandledException;

--- a/src/GIMI-ModManager.WinUI/Services/ModRandomizationService.cs
+++ b/src/GIMI-ModManager.WinUI/Services/ModRandomizationService.cs
@@ -198,4 +198,4 @@ public class ModRandomizationService
             string.Join(", ", selectedCategories.Select(c => c.DisplayNamePlural)),
             TimeSpan.FromSeconds(5));
     }
-} 
+}

--- a/src/GIMI-ModManager.WinUI/Services/ModRandomizationService.cs
+++ b/src/GIMI-ModManager.WinUI/Services/ModRandomizationService.cs
@@ -1,0 +1,201 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using GIMI_ModManager.Core.Contracts.Services;
+using GIMI_ModManager.Core.GamesService;
+using GIMI_ModManager.Core.GamesService.Interfaces;
+using GIMI_ModManager.Core.Services;
+using GIMI_ModManager.WinUI.Contracts.Services;
+using GIMI_ModManager.WinUI.Services.AppManagement;
+using GIMI_ModManager.WinUI.Services.Notifications;
+using GIMI_ModManager.WinUI.Services.ModHandling;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Serilog;
+
+namespace GIMI_ModManager.WinUI.Services;
+
+public class ModRandomizationService
+{
+    private readonly IGameService _gameService;
+    private readonly ISkinManagerService _skinManagerService;
+    private readonly IWindowManagerService _windowManagerService;
+    private readonly CharacterSkinService _characterSkinService;
+    private readonly ElevatorService _elevatorService;
+    private readonly NotificationManager _notificationManager;
+    private readonly ILogger _logger;
+    private static readonly Random Random = new();
+
+    public ModRandomizationService(
+        IGameService gameService,
+        ISkinManagerService skinManagerService,
+        IWindowManagerService windowManagerService,
+        CharacterSkinService characterSkinService,
+        ElevatorService elevatorService,
+        NotificationManager notificationManager,
+        ILogger logger)
+    {
+        _gameService = gameService;
+        _skinManagerService = skinManagerService;
+        _windowManagerService = windowManagerService;
+        _characterSkinService = characterSkinService;
+        _elevatorService = elevatorService;
+        _notificationManager = notificationManager;
+        _logger = logger.ForContext<ModRandomizationService>();
+    }
+
+    public async Task ShowRandomizeModsDialog()
+    {
+        var dialog = new ContentDialog
+        {
+            Title = "Randomize Mods",
+            PrimaryButtonText = "Randomize",
+            CloseButtonText = "Cancel",
+            DefaultButton = ContentDialogButton.Primary
+        };
+
+        var categories = _gameService.GetCategories();
+        var stackPanel = new StackPanel();
+
+        stackPanel.Children.Add(new TextBlock
+        {
+            Text = "Select the categories you want to randomize mods for:"
+        });
+
+        stackPanel.Children.Add(new TextBlock
+        {
+            Text = "Note: This will only randomize mod folders that are meant to only have one mod active. So 'Others __' folders will not be randomized. While only one mod wil be enabled per in game character skin",
+            TextWrapping = TextWrapping.WrapWholeWords,
+            Margin = new Thickness(0, 0, 0, 10)
+        });
+
+        foreach (var category in categories)
+        {
+            var checkBox = new CheckBox
+            {
+                Content = category.DisplayNamePlural,
+                IsChecked = true
+            };
+            stackPanel.Children.Add(checkBox);
+        }
+
+        stackPanel.Children.Add(new CheckBox
+        {
+            Margin = new Thickness(0, 10, 0, 0),
+            Content = "Allow no mods as a result. This means it is possible for no mods to be enabled for a mod folder",
+            IsChecked = false
+        });
+
+        stackPanel.Children.Add(new TextBlock
+        {
+            Text = "I suggest creating a preset (or a backup) of your mods before randomizing if you have a lot of enabled mods",
+            TextWrapping = TextWrapping.WrapWholeWords,
+            Margin = new Thickness(0, 10, 0, 0)
+        });
+
+        dialog.Content = stackPanel;
+
+        var result = await _windowManagerService.ShowDialogAsync(dialog);
+        if (result != ContentDialogResult.Primary)
+        {
+            return;
+        }
+
+        var selectedCategories = stackPanel.Children
+            .OfType<CheckBox>()
+            .SkipLast(1)
+            .Where(c => c.IsChecked == true)
+            .Select(c => categories.First(cat => cat.DisplayNamePlural.Equals(c.Content)))
+            .ToList();
+
+        var allowNoMods = stackPanel.Children
+            .OfType<CheckBox>()
+            .Last()
+            .IsChecked == true;
+
+        if (selectedCategories.Count == 0)
+        {
+            _notificationManager.ShowNotification("No categories selected", "No categories were selected to randomize.",
+                TimeSpan.FromSeconds(5));
+            return;
+        }
+
+        try
+        {
+            await Task.Run(async () =>
+            {
+                var modLists = _skinManagerService.CharacterModLists
+                    .Where(modList => selectedCategories.Contains(modList.Character.ModCategory))
+                    .Where(modList => !modList.Character.IsMultiMod)
+                    .ToList();
+
+                foreach (var modList in modLists)
+                {
+                    var mods = modList.Mods.ToList();
+
+                    if (mods.Count == 0)
+                        continue;
+
+                    // Need special handling for characters because they have an in game skins
+                    if (modList.Character is ICharacter { Skins.Count: > 1 } character)
+                    {
+                        var skinModMap = await _characterSkinService.GetAllModsBySkinAsync(character)
+                            .ConfigureAwait(false);
+                        if (skinModMap is null)
+                            continue;
+
+                        // Don't know what to do with undetectable mods
+                        skinModMap.UndetectableMods.ForEach(mod => modList.DisableMod(mod.Id));
+
+                        foreach (var (_, skinMods) in skinModMap.ModsBySkin)
+                        {
+                            if (skinMods.Count == 0)
+                                continue;
+
+                            foreach (var mod in skinMods.Where(mod => modList.IsModEnabled(mod)))
+                            {
+                                modList.DisableMod(mod.Id);
+                            }
+
+                            var randomModIndex = Random.Next(0, skinMods.Count + (allowNoMods ? 1 : 0));
+
+                            if (randomModIndex == skinMods.Count)
+                                continue;
+
+                            modList.EnableMod(skinMods.ElementAt(randomModIndex).Id);
+                        }
+
+                        continue;
+                    }
+
+                    foreach (var characterSkinEntry in mods.Where(characterSkinEntry => characterSkinEntry.IsEnabled))
+                    {
+                        modList.DisableMod(characterSkinEntry.Id);
+                    }
+
+                    var randomIndex = Random.Next(0, mods.Count + (allowNoMods ? 1 : 0));
+                    if (randomIndex == mods.Count)
+                        continue;
+
+                    modList.EnableMod(mods[randomIndex].Id);
+                }
+            });
+        }
+        catch (Exception e)
+        {
+            _logger.Error(e, "Failed to randomize mods");
+            _notificationManager.ShowNotification("Failed to randomize mods", e.Message, TimeSpan.FromSeconds(5));
+            return;
+        }
+
+        if (_elevatorService.ElevatorStatus == ElevatorStatus.Running)
+        {
+            await Task.Run(() => _elevatorService.RefreshGenshinMods());
+        }
+
+        _notificationManager.ShowNotification("Mods randomized",
+            "Mods have been randomized for the categories: " +
+            string.Join(", ", selectedCategories.Select(c => c.DisplayNamePlural)),
+            TimeSpan.FromSeconds(5));
+    }
+} 

--- a/src/GIMI-ModManager.WinUI/ViewModels/CharactersViewModel.cs
+++ b/src/GIMI-ModManager.WinUI/ViewModels/CharactersViewModel.cs
@@ -43,6 +43,7 @@ public partial class CharactersViewModel : ObservableRecipient, INavigationAware
     private readonly ModUpdateAvailableChecker _modUpdateAvailableChecker;
     private readonly ModPresetHandlerService _modPresetHandlerService;
     private readonly BusyService _busyService;
+    private readonly ModRandomizationService _modRandomizationService;
 
     public readonly GenshinProcessManager GenshinProcessManager;
     public readonly ThreeDMigtoProcessManager ThreeDMigtoProcessManager;
@@ -100,7 +101,7 @@ public partial class CharactersViewModel : ObservableRecipient, INavigationAware
         ModDragAndDropService modDragAndDropService, ModNotificationManager modNotificationManager,
         ModCrawlerService modCrawlerService, ModSettingsService modSettingsService,
         ModUpdateAvailableChecker modUpdateAvailableChecker, ModPresetHandlerService modPresetHandlerService,
-        BusyService busyService, ILanguageLocalizer localizer)
+        BusyService busyService, ILanguageLocalizer localizer, ModRandomizationService modRandomizationService)
     {
         _gameService = gameService;
         _logger = logger.ForContext<CharactersViewModel>();
@@ -119,6 +120,7 @@ public partial class CharactersViewModel : ObservableRecipient, INavigationAware
         _modPresetHandlerService = modPresetHandlerService;
         _busyService = busyService;
         _localizer = localizer;
+        _modRandomizationService = modRandomizationService;
 
         ElevatorService.PropertyChanged += (_, args) =>
         {
@@ -1202,6 +1204,9 @@ public partial class CharactersViewModel : ObservableRecipient, INavigationAware
                     characters.ThenBy(x => x.Character.DisplayName
                     ));
     }
+
+    [RelayCommand]
+    private Task RandomizeMods() => _modRandomizationService.ShowRandomizeModsDialog();
 }
 
 public sealed class GridFilter

--- a/src/GIMI-ModManager.WinUI/ViewModels/PresetViewModel.cs
+++ b/src/GIMI-ModManager.WinUI/ViewModels/PresetViewModel.cs
@@ -35,7 +35,8 @@ public partial class PresetViewModel(
     INavigationService navigationService,
     BusyService busyService,
     ModPresetHandlerService modPresetHandlerService,
-    ILocalSettingsService localSettingsService)
+    ILocalSettingsService localSettingsService,
+    ModRandomizationService modRandomizationService)
     : ObservableRecipient, INavigationAware
 {
     public readonly ElevatorService ElevatorService = elevatorService;
@@ -51,6 +52,7 @@ public partial class PresetViewModel(
     private readonly ILogger _logger = logger.ForContext<PresetViewModel>();
     private readonly ILocalSettingsService _localSettingsService = localSettingsService;
     private readonly ModPresetHandlerService _modPresetHandlerService = modPresetHandlerService;
+    private readonly ModRandomizationService _modRandomizationService = modRandomizationService;
     private static readonly Random Random = new();
 
 
@@ -305,181 +307,8 @@ public partial class PresetViewModel(
         ReloadPresets();
     }
 
-    [RelayCommand(CanExecute = nameof(IsNotBusy))]
-    private async Task RandomizeMods()
-    {
-        var dialog = new ContentDialog
-        {
-            Title = "Randomize Mods",
-            PrimaryButtonText = "Randomize",
-            CloseButtonText = "Cancel",
-            DefaultButton = ContentDialogButton.Primary
-        };
-
-
-        var categories = _gameService.GetCategories();
-
-        var stackPanel = new StackPanel();
-
-        stackPanel.Children.Add(new TextBlock
-        {
-            Text = "Select the categories you want to randomize mods for:"
-        });
-
-        stackPanel.Children.Add(new TextBlock
-        {
-            Text =
-                "Note: This will only randomize mod folders that are meant to only have one mod active. So 'Others __' folders will not be randomized. While only one mod wil be enabled per in game character skin",
-            TextWrapping = TextWrapping.WrapWholeWords,
-            Margin = new Thickness(0, 0, 0, 10)
-        });
-
-
-        foreach (var category in categories)
-        {
-            var checkBox = new CheckBox
-            {
-                Content = category.DisplayNamePlural,
-                IsChecked = true
-            };
-
-            stackPanel.Children.Add(checkBox);
-        }
-
-        stackPanel.Children.Add(new CheckBox
-        {
-            Margin = new Thickness(0, 10, 0, 0),
-            Content = "Allow no mods as a result. This means it is possible for no mods to be enabled for a mod folder",
-            IsChecked = true
-        });
-
-
-        stackPanel.Children.Add(new TextBlock
-        {
-            Text =
-                "I suggest creating a preset (or a backup) of your mods before randomizing if you have a lot of enabled mods",
-            TextWrapping = TextWrapping.WrapWholeWords,
-            Margin = new Thickness(0, 10, 0, 0)
-        });
-
-
-        dialog.Content = stackPanel;
-
-        var result = await _windowManagerService.ShowDialogAsync(dialog);
-
-
-        if (result != ContentDialogResult.Primary)
-        {
-            return;
-        }
-
-        using var _ = StartBusy();
-
-
-        var selectedCategories = stackPanel.Children
-            .OfType<CheckBox>()
-            .SkipLast(1)
-            .Where(c => c.IsChecked == true)
-            .Select(c => categories.First(cat => cat.DisplayNamePlural.Equals(c.Content)))
-            .ToList();
-
-        var allowNoMods = stackPanel.Children
-            .OfType<CheckBox>()
-            .Last()
-            .IsChecked == true;
-
-        if (selectedCategories.Count == 0)
-        {
-            _notificationManager.ShowNotification("No categories selected", "No categories were selected to randomize.",
-                TimeSpan.FromSeconds(5));
-            return;
-        }
-
-
-        try
-        {
-            await Task.Run(async () =>
-            {
-                var modLists = _skinManagerService.CharacterModLists
-                    .Where(modList => selectedCategories.Contains(modList.Character.ModCategory))
-                    .Where(modList => !modList.Character.IsMultiMod)
-                    .ToList();
-
-                foreach (var modList in modLists)
-                {
-                    var mods = modList.Mods.ToList();
-
-                    if (mods.Count == 0)
-                        continue;
-
-                    // Need special handling for characters because they have an in game skins
-                    if (modList.Character is ICharacter { Skins.Count: > 1 } character)
-                    {
-                        var skinModMap = await _characterSkinService.GetAllModsBySkinAsync(character)
-                            .ConfigureAwait(false);
-                        if (skinModMap is null)
-                            continue;
-
-                        // Don't know what to do with undetectable mods
-                        skinModMap.UndetectableMods.ForEach(mod => modList.DisableMod(mod.Id));
-
-                        foreach (var (_, skinMods) in skinModMap.ModsBySkin)
-                        {
-                            if (skinMods.Count == 0)
-                                continue;
-
-                            foreach (var mod in skinMods.Where(mod => modList.IsModEnabled(mod)))
-                            {
-                                modList.DisableMod(mod.Id);
-                            }
-
-                            var randomModIndex = Random.Next(0, skinMods.Count + (allowNoMods ? 1 : 0));
-
-                            if (randomModIndex == skinMods.Count)
-                                continue;
-
-                            modList.EnableMod(skinMods.ElementAt(randomModIndex).Id);
-                        }
-
-
-                        continue;
-                    }
-
-
-                    foreach (var characterSkinEntry in mods.Where(characterSkinEntry => characterSkinEntry.IsEnabled))
-                    {
-                        modList.DisableMod(characterSkinEntry.Id);
-                    }
-
-
-                    var randomIndex = Random.Next(0, mods.Count + (allowNoMods ? 1 : 0));
-                    if (randomIndex == mods.Count)
-                        continue;
-
-                    modList.EnableMod(mods[randomIndex].Id);
-                }
-            });
-        }
-        catch (Exception e)
-        {
-            _logger.Error(e, "Failed to randomize mods");
-            _notificationManager.ShowNotification("Failed to randomize mods", e.Message, TimeSpan.FromSeconds(5));
-            return;
-        }
-
-        if (CanAutoSync())
-        {
-            await Task.Run(() => ElevatorService.RefreshGenshinMods());
-        }
-
-
-        _notificationManager.ShowNotification("Mods randomized",
-            "Mods have been randomized for the categories: " +
-            string.Join(", ",
-                selectedCategories.Select(c =>
-                    c.DisplayNamePlural)),
-            TimeSpan.FromSeconds(5));
-    }
+    [RelayCommand]
+    private Task RandomizeMods() => _modRandomizationService.ShowRandomizeModsDialog();
 
 
     [RelayCommand]

--- a/src/GIMI-ModManager.WinUI/Views/CharactersPage.xaml
+++ b/src/GIMI-ModManager.WinUI/Views/CharactersPage.xaml
@@ -262,6 +262,18 @@
                                                 </DataTemplate>
                                             </ItemsRepeater.ItemTemplate>
                                         </ItemsRepeater>
+                                        
+                                        <Rectangle Height="1" Fill="{ThemeResource DividerStrokeColorDefaultBrush}" />
+                                        
+                                        <Button 
+                                            HorizontalAlignment="Stretch"
+                                            Command="{x:Bind ViewModel.RandomizeModsCommand}"
+                                            ToolTipService.ToolTip="Opens a dialog with more info">
+                                            <StackPanel Orientation="Horizontal" Spacing="8">
+                                                <FontIcon Glyph="&#xE8B1;" />
+                                                <TextBlock Text="Randomize Mods" />
+                                            </StackPanel>
+                                        </Button>
                                     </StackPanel>
                                 </ScrollViewer>
                             </Flyout>


### PR DESCRIPTION
every time I want to randomize the mods, I have to click `preset` menu at the sidebar, then click the `random` button at below. It's quite inconvenient.

This PR add a button to randomize mods at the charactors page.

![image](https://github.com/user-attachments/assets/ce31ef5d-8e06-488b-a493-37403a618dc0)
