### PR TITLE
Fix Mod Installer page not closing after mod succesfully installed

### DIFF
--- a/src/GIMI-ModManager.WinUI/ViewModels/ModPageViewModels/ModPageVM.cs
+++ b/src/GIMI-ModManager.WinUI/ViewModels/ModPageViewModels/ModPageVM.cs
@@ -304,6 +304,7 @@ public partial class ModPageVM : ObservableRecipient
             }
 
             fileInfoVm.Status = ModFileInfoVm.InstallStatus.Installed;
+            _window.Close();
         }
         catch (TaskCanceledException)
         {


### PR DESCRIPTION
### Summary
This PR adds a close window line on the Mod installer page after the mod is successfully installed, to avoid the issue where windows remaining open when installing or updating mods

### Implementation
|Before| Now|
|------|------|
|<video src="https://github.com/user-attachments/assets/562ea5b6-0f73-46dd-be98-afa94e0e1882" />| <video src="https://github.com/user-attachments/assets/87bea1ae-8ec5-428a-b6a2-1c75dcfe0277" />