### PR TITLE
Fix: CommandExecution TargetPath fails with spaces

### DIFF
--- a/src/GIMI-ModManager.Core/Services/CommandService/CommandService.cs
+++ b/src/GIMI-ModManager.Core/Services/CommandService/CommandService.cs
@@ -90,7 +90,7 @@ public sealed class CommandService(ILogger logger)
             FileName = SpecialVariables.ReplaceVariables(options.ExecutionOptions.Command,
                 options.SpecialVariablesInput),
             Arguments = SpecialVariables.ReplaceVariables(options.ExecutionOptions.Arguments,
-                options.SpecialVariablesInput),
+                options.SpecialVariablesInput, quoteValuesWithSpaces: true),
             WorkingDirectory = SpecialVariables.ReplaceVariables(options.ExecutionOptions.WorkingDirectory,
                 options.SpecialVariablesInput),
             UseShellExecute = options.ExecutionOptions.UseShellExecute,

--- a/src/GIMI-ModManager.Core/Services/CommandService/SpecialVariables.cs
+++ b/src/GIMI-ModManager.Core/Services/CommandService/SpecialVariables.cs
@@ -12,7 +12,7 @@ public static class SpecialVariables
 
 
     [return: NotNullIfNotNull(nameof(input))]
-    public static string? ReplaceVariables(string? input, SpecialVariablesInput? specialVariables)
+    public static string? ReplaceVariables(string? input, SpecialVariablesInput? specialVariables, bool quoteValuesWithSpaces = false)
     {
         if (input is null)
             return null;
@@ -22,9 +22,46 @@ public static class SpecialVariables
 
         foreach (var variable in specialVariables.GetSpecialVariables())
         {
-            input = input.Replace(variable, specialVariables.GetVariable(variable));
+            var value = specialVariables.GetVariable(variable);
+
+            if (quoteValuesWithSpaces && value.Contains(' '))
+            {
+                input = SmartReplace(input, variable, value);
+            }
+            else
+            {
+                input = input.Replace(variable, value);
+            }
         }
 
+        return input;
+    }
+
+    private static string SmartReplace(string input, string variable, string value)
+    {
+        int index = 0;
+        while ((index = input.IndexOf(variable, index, StringComparison.Ordinal)) != -1)
+        {
+            int quotesBefore = 0;
+            for (int i = 0; i < index; i++)
+            {
+                if (input[i] == '\"') quotesBefore++;
+            }
+
+            bool isInsideQuotes = quotesBefore % 2 != 0;
+
+            if (isInsideQuotes)
+            {
+                input = input.Remove(index, variable.Length).Insert(index, value);
+                index += value.Length;
+            }
+            else
+            {
+                string quotedValue = $"\"{value}\"";
+                input = input.Remove(index, variable.Length).Insert(index, quotedValue);
+                index += quotedValue.Length;
+            }
+        }
         return input;
     }
 }


### PR DESCRIPTION
Fixes a bug where resolving the "{{TargetPath}}" parameter in the CommandService would fail execution if the path contained spaces by properly escaping arguments.